### PR TITLE
Add daemon support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -113,37 +113,11 @@ int main( int argc, const char** argv )
 
   if (filename.empty())
   {
-    std::string line;
-    while (std::getline(std::cin, line))
+    std::string filename;
+    while (std::getline(std::cin, filename))
     {
-      std::istringstream is(line);
-      std::vector<std::string> args;
-      args.push_back("tmp");
-      args.insert(args.end(), std::istream_iterator<std::string>(is), std::istream_iterator<std::string>());
-      try
-      {
-        cmd.reset();
-        cmd.parse(args);
-
-        filename = fileArg.getValue();
-        outputJson = jsonSwitch.getValue();
-        detectRegion = detectRegionSwitch.getValue();
-        templateRegion = templateRegionArg.getValue();
-        topn = topNArg.getValue();
-
-        alpr.setTopN(topn);
-        if (detectRegion)
-          alpr.setDetectRegion(detectRegion);
-        if (templateRegion.empty() == false)
-          alpr.setDefaultRegion(templateRegion);
-
-        frame = cv::imread( filename );
-        detectandshow( &alpr, frame, "", outputJson);
-      }
-      catch (TCLAP::ArgException &e)    // catch any exceptions
-      {
-        std::cerr << "error: " << e.error() << " for arg " << e.argId() << std::endl;
-      }
+      frame = cv::imread( filename );
+      detectandshow( &alpr, frame, "", outputJson);
     }
   }
   else if (filename == "webcam")


### PR DESCRIPTION
Hey,

I added a basic daemon, can you look at Silex@26fb47dce499f56fd24 ? It's to avoid the long loading time of alpr. This is not very mature yet but it seems to work, I'm mainly starting this PR to get a bit of input about this from you, in order to "do the right thing".

The idea is that you start it like: ./alpr -c us without a filename and then you can type filenames, or options like -j -n 5 somefile.jpg and it returns the data. This shaves about 300ms of loading time and it's great if you receive a lot of images from a live stream because it analyzes images at maximum rate (250ms per image instead of ~500ms).

I started it as a separate alpr-daemon executable but then realised I could reuse code for parsing options. Eventually I'll probably make this a separate executable but I need to work on a little language for communication with ALPR.
