### PR TITLE
Update plate_size_quota.py

### DIFF
--- a/plate_size_quota.py
+++ b/plate_size_quota.py
@@ -4,7 +4,7 @@ import shutil
 BYTES_IN_A_MEGABYTE = 1048576
 
 size_quota_mb=200000
-size_quota_bytes = size_quota_mb * 1048576
+size_quota_bytes = size_quota_mb * BYTES_IN_A_MEGABYTE
 dir='/var/www/html/plates/'
 
 


### PR DESCRIPTION
refactored the repeated BYTES_IN_A_MEGABYTE value.  Thought it more efficient than repeating the value.
