### PR TITLE
Changes to Videobuf.cpp to enhance video capture performance and to provide conenction status

### DIFF
--- a/src/video/videobuffer.cpp
+++ b/src/video/videobuffer.cpp
@@ -152,7 +152,7 @@ void getALPRImages(cv::VideoCapture cap, VideoDispatcher* dispatcher)
   cv::Mat frame1;
   cv::Mat frame2;
   cv::Mat* receiveframe;
-  bool receiveframeisframe1 = TRUE;
+  bool receiveframeisframe1 = true;
 
   while (dispatcher->active)
   {


### PR DESCRIPTION
Hi Matt,
After studying and analysing your OpenALPR project for several months, this is my first official contribution to the project. This is the first time ever that I use the tools and procedures, so I hope it works as intended. Please let me know.

For a start (there is more to follow) two changes to videobuff.cpp.

The first one to solve the issue that I saw that the main-program was kept waiting for a newly captured frame at every videobuffer.getLatestFrame, even though an unprocessed frame was available.

The second one to give indication to the user while connecting to the video stream. 
For some reason there are some extra deletions and insertions shown in this change.

Kind regards,
Kees
