### PR TITLE
Exposed the third param for a run-time dir to the C# binding thus preventing crashes

### DIFF
--- a/bindings/csharp/openalpr-net/openalpr-net.cpp
+++ b/bindings/csharp/openalpr-net/openalpr-net.cpp
@@ -295,7 +295,7 @@ namespace openalprnet {
 	{
 	public:
 		// Allocate the native object on the C++ Heap via a constructor
-		AlprNet(System::String^ country, System::String^ configFile) : m_Impl( new Alpr(marshal_as<std::string>(country), marshal_as<std::string>(configFile)) ) { }
+		AlprNet(System::String^ country, System::String^ configFile, System::String^ runtimeDir) : m_Impl( new Alpr(marshal_as<std::string>(country), marshal_as<std::string>(configFile), marshal_as<std::string>(runtimeDir)) ) { }
 
 		// Deallocate the native object on a destructor
 		~AlprNet(){


### PR DESCRIPTION
Hello Matt, it's Dimitar Dobrev. I am sending you a patch for the crash I had with the .NET binding. I am actually puzzled about why it works for you. Anyway, let me know of there are problems with the patch.