### PR TITLE
filterByOuterMask: Re-initialize mask for every contour to get a correct...

### DIFF
--- a/src/openalpr/textdetection/characteranalysis.cpp
+++ b/src/openalpr/textdetection/characteranalysis.cpp
@@ -549,7 +549,8 @@ namespace alpr
 
       totalChars++;
 
-      drawContours(tempFullContour, textContours.contours, i, Scalar(255,255,255), CV_FILLED, 8, textContours.hierarchy);
+	  tempFullContour = Mat::zeros(plateMask.size(), CV_8U);
+	  drawContours(tempFullContour, textContours.contours, i, Scalar(255,255,255), CV_FILLED, 8, textContours.hierarchy);
       bitwise_and(tempFullContour, plateMask, tempMaskedContour);
 
       float beforeMaskWhiteness = mean(tempFullContour)[0];


### PR DESCRIPTION
Hi Matt,

When checking on the segmentfiltering I recognised that tempFullcontour should be re-initialised in the loop to make sure that every separate contour is evaluated correctly.

Kees