### PR TITLE
Initialize scale_factor separately for every picture separately

### DIFF
--- a/src/openalpr/alpr_impl.cpp
+++ b/src/openalpr/alpr_impl.cpp
@@ -134,7 +134,8 @@ namespace alpr
 
     queue<PlateRegion> plateQueue;
     for (unsigned int i = 0; i < warpedPlateRegions.size(); i++)
-      plateQueue.push(warpedPlateRegions[i]);
+		if (((warpedPlateRegions[i].rect.height + warpedPlateRegions[i].rect.y) < grayImg.rows) && ((warpedPlateRegions[i].rect.width + warpedPlateRegions[i].rect.x) < grayImg.cols))
+			plateQueue.push(warpedPlateRegions[i]);
 
     int platecount = 0;
     while(!plateQueue.empty())

--- a/src/openalpr/detection/detector.cpp
+++ b/src/openalpr/detection/detector.cpp
@@ -28,7 +28,6 @@ namespace alpr
   Detector::Detector(Config* config)
   {
     this->config = config;
-    this->scale_factor = 1.0f;
 
   }
 

--- a/src/openalpr/detection/detectorcpu.cpp
+++ b/src/openalpr/detection/detectorcpu.cpp
@@ -92,6 +92,7 @@ namespace alpr
       if (config->debugDetector)
         std::cout << "Input detection image is too tall.  Resizing with scale: " << this->scale_factor << endl;
     }
+	else scale_factor = 1;
 
     int w = frame.size().width;
     int h = frame.size().height;

--- a/src/openalpr/detection/detectorcuda.cpp
+++ b/src/openalpr/detection/detectorcuda.cpp
@@ -87,6 +87,8 @@ namespace alpr
       if (config->debugDetector)
         std::cout << "Input detection image is too tall.  Resizing with scale: " << this->scale_factor << endl;
     }
+	else scale_factor = 1;
+
 
     int w = frame.size().width;
     int h = frame.size().height;


### PR DESCRIPTION
When alpr is used with a series of pictures of different sizes scale_factor needs to be calculated or set to 1 for every picture separately. 
A small picture processed after a large picture should be analysed with scale_factor = 1.