### PR TITLE
fixes assertion in morph detector

### DIFF
--- a/src/openalpr/detection/detectormorph.cpp
+++ b/src/openalpr/detection/detectormorph.cpp
@@ -50,8 +50,16 @@ namespace alpr {
   vector<PlateRegion> DetectorMorph::detect(Mat frame, std::vector<cv::Rect> regionsOfInterest) {
 
     Mat frame_gray,frame_gray_cp;
-    cvtColor(frame, frame_gray, CV_BGR2GRAY);
-    
+
+    if (frame.channels() > 2)
+    {
+      cvtColor( frame, frame_gray, CV_BGR2GRAY );
+    }
+    else
+    {
+      frame.copyTo(frame_gray);
+    }
+
     frame_gray.copyTo(frame_gray_cp);
     blur(frame_gray, frame_gray, Size(5, 5));
 


### PR DESCRIPTION
I was testing morph detector and found out it had the same issue as the gpu detector, it needs this check before converting to grayscale to avoid the assertion.