### PR TITLE
Fixing compiler error for MAC OS 10.10.3

### DIFF
--- a/src/misc_utilities/classifychars.cpp
+++ b/src/misc_utilities/classifychars.cpp
@@ -42,6 +42,7 @@ using namespace alpr;
 const int LEFT_ARROW_KEY = 2;
 const int RIGHT_ARROW_KEY = 3;
 const int SPACE_KEY = 32;
+const string SPACE = " ";
 const int ENTER_KEY = 13;
 const int ESCAPE_KEY = 27;
 

--- a/src/openalpr/support/utf8.cpp
+++ b/src/openalpr/support/utf8.cpp
@@ -1,5 +1,5 @@
 #include "utf8.h"
-
+#include <string>
 
 std::string utf8chr(int cp)
 {


### PR DESCRIPTION
Fixing compiler errors:
error: implicit instantiation of undefined template
error: use of undeclared identifier 'SPACE'

