### PR TITLE
mkdir needs to create intermediate directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ run apt-get update && apt-get install -y \
 copy . /srv/openalpr
 
 # Setup the build directory
-run mkdir /srv/openalpr/src/build
+run mkdir -p /srv/openalpr/src/build
 workdir /srv/openalpr/src/build
 
 # Setup the compile environment


### PR DESCRIPTION
Dockerfile build failed with

```
Step 4 : RUN mkdir /srv/openalpr/src/build
 ---> Running in f00f272fc452
mkdir: cannot create directory '/srv/openalpr/src/build': No such file or directory
```

The change runs `mkdir` as `mkdir -p` to create intermediate directories as needed.