### PR TITLE
TopN values strange behavior #135

### DIFF
--- a/src/openalpr/alpr_impl.cpp
+++ b/src/openalpr/alpr_impl.cpp
@@ -197,33 +197,28 @@ namespace alpr
           if (pp >= topN)
             break;
 
-          int plate_char_length = utf8::distance(ppResults[pp].letters.begin(), ppResults[pp].letters.end());
-          if (plate_char_length >= config->postProcessMinCharacters &&
-            plate_char_length <= config->postProcessMaxCharacters)
-          {
-            // Set our "best plate" match to either the first entry, or the first entry with a postprocessor template match
-            if (bestPlateIndex == 0 && ppResults[pp].matchesTemplate)
-              bestPlateIndex = plateResult.topNPlates.size();
-            
-            AlprPlate aplate;
-            aplate.characters = ppResults[pp].letters;
-            aplate.overall_confidence = ppResults[pp].totalscore;
-            aplate.matches_template = ppResults[pp].matchesTemplate;
-            
-            // Grab detailed results for each character
-            for (unsigned int c_idx = 0; c_idx < ppResults[pp].letter_details.size(); c_idx++)
-            {
-              AlprChar character_details;
-              character_details.character = ppResults[pp].letter_details[c_idx].letter;
-              character_details.confidence = ppResults[pp].letter_details[c_idx].totalscore;
-              cv::Rect char_rect = pipeline_data.charRegions[ppResults[pp].letter_details[c_idx].charposition];
-              std::vector<AlprCoordinate> charpoints = getCharacterPoints(char_rect, &pipeline_data );
-              for (int cpt = 0; cpt < 4; cpt++)
-                character_details.corners[cpt] = charpoints[cpt];
-              aplate.character_details.push_back(character_details);
-            }
-            plateResult.topNPlates.push_back(aplate);
-          }
+	      // Set our "best plate" match to either the first entry, or the first entry with a postprocessor template match
+	      if (bestPlateIndex == 0 && ppResults[pp].matchesTemplate)
+	        bestPlateIndex = plateResult.topNPlates.size();
+	        
+	      AlprPlate aplate;
+	      aplate.characters = ppResults[pp].letters;
+	      aplate.overall_confidence = ppResults[pp].totalscore;
+	      aplate.matches_template = ppResults[pp].matchesTemplate;
+	        
+	      // Grab detailed results for each character
+	      for (unsigned int c_idx = 0; c_idx < ppResults[pp].letter_details.size(); c_idx++)
+	      {
+	        AlprChar character_details;
+	        character_details.character = ppResults[pp].letter_details[c_idx].letter;
+	        character_details.confidence = ppResults[pp].letter_details[c_idx].totalscore;
+            cv::Rect char_rect = pipeline_data.charRegions[ppResults[pp].letter_details[c_idx].charposition];
+	        std::vector<AlprCoordinate> charpoints = getCharacterPoints(char_rect, &pipeline_data );
+	        for (int cpt = 0; cpt < 4; cpt++)
+	          character_details.corners[cpt] = charpoints[cpt];
+	        aplate.character_details.push_back(character_details);
+	      }
+	      plateResult.topNPlates.push_back(aplate);
 
         }
 


### PR DESCRIPTION
1. Post processing was limiting the number of results to TopN.  After that, you were filtering for results that were too short or too long.  So you would end up with fewer results than TopN in many cases.

2.  The commit seems to also have removed the odd issue with the higher results being filtered out depending on the value of topN.  I'm guessing there was a bug in the pruning code in the post-processor.