### PR TITLE
Add support for local webcam in alprd

### DIFF
--- a/config/alprd.conf
+++ b/config/alprd.conf
@@ -1,5 +1,3 @@
-
-
 [daemon]
 
 ; country determines the training dataset used for recognizing plates.  Valid values are: us, eu
@@ -13,13 +11,10 @@ site_id = your-unique-sitename
 
 stream = http://127.0.0.1/example_video_stream.mjpeg
 ;stream = http://127.0.0.1/example_second_stream.mjpeg
-
+;stream = webcam
 
 ; topn is the number of possible plate character variations to report
 topn = 10
-
-
-
 
 ; Determines whether images that contain plates should be stored to disk
 store_plates = 0

--- a/src/video/videobuffer.cpp
+++ b/src/video/videobuffer.cpp
@@ -107,7 +107,15 @@ void imageCollectionThread(void* arg)
     {
       cv::VideoCapture cap=cv::VideoCapture();
       dispatcher->log_info("Video stream connecting...");
-      cap.open(dispatcher->mjpeg_url);
+
+      if (dispatcher->mjpeg_url == "webcam")
+      {
+        cap.open(0);
+      }
+      else
+      {
+        cap.open(dispatcher->mjpeg_url);
+      }
       
       if (cap.isOpened())
       {


### PR DESCRIPTION
Just add stream=webcam to alprd.conf

Implementation uses the same mechanism used in "alpr": 
cv::VideoCapture cap=cv::VideoCapture();
cap.open(0);