### PR TITLE
Added configuration option to disable output of character details in results

### DIFF
--- a/config/openalpr.conf.in
+++ b/config/openalpr.conf.in
@@ -59,6 +59,8 @@ postprocess_confidence_skip_level = 80
 postprocess_min_characters = 4
 postprocess_max_characters = 8
 
+; Return detailed results for each character
+results_character_details = 0
 
 debug_general         = 0
 debug_timing          = 0

--- a/src/openalpr/config.cpp
+++ b/src/openalpr/config.cpp
@@ -180,6 +180,8 @@ namespace alpr
     postProcessMinCharacters = getInt(ini, "", "postprocess_min_characters", 100);
     postProcessMaxCharacters = getInt(ini, "", "postprocess_max_characters", 100);
 
+    resultsCharacterDetails = getBoolean(ini,"", "results_character_details", false);
+
     debugGeneral = 	getBoolean(ini, "", "debug_general",		false);
     debugTiming = 	getBoolean(ini, "", "debug_timing",		false);
     debugPrewarp = 	getBoolean(ini, "", "debug_prewarp",		false);

--- a/src/openalpr/config.h
+++ b/src/openalpr/config.h
@@ -101,10 +101,10 @@ namespace alpr
 
       float postProcessMinConfidence;
       float postProcessConfidenceSkipLevel;
-      unsigned int postProcessMaxSubstitutions;
       unsigned int postProcessMinCharacters;
       unsigned int postProcessMaxCharacters;
 
+      unsigned int resultsCharacterDetails;
 
       bool debugGeneral;
       bool debugTiming;


### PR DESCRIPTION
Generating the results for the character details in alpr_impl.cpp can add significant time to the overall plate analysis.  When returning 10 plates, that code took 16% of the total time.  The data returned seems to only be valuable to certain clients of the library (not the default main.cpp client).

I added timing output and a configuration flag to disable the logic.

Since I don't know the context of the functionality, there might be a better way of handling this, like passing the flag directly as input to the analyze() method or by outputing the character details only during debugging.