### PR TITLE
Change ENTER_KEY code from 10 to 13

### DIFF
--- a/src/misc_utilities/classifychars.cpp
+++ b/src/misc_utilities/classifychars.cpp
@@ -54,7 +54,7 @@ const int LEFT_ARROW_KEY = 81;
 const int RIGHT_ARROW_KEY = 83;
 const int SPACE_KEY = 32;
 const string SPACE = " ";
-const int ENTER_KEY = 10;
+const int ENTER_KEY = 13;
 const int ESCAPE_KEY = 27;
 
 const int DOWN_ARROW_KEY = 84;


### PR DESCRIPTION
I changed the `ENTER_KEY` code from 10 to 13, because it's not work on Ubuntu, but I only tested on Ubuntu platform, please check it.