### PR TITLE
Patch for compatibility with openalpr-ios 2_0

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,22 +52,22 @@ IF (WIN32 AND WITH_DAEMON)
   SET(WITH_DAEMON OFF)
 ENDIF()
 
-IF(Tesseract_IOS_FRAMEWORK_PATH AND Leptonica_IOS_FRAMEWORK_PATH) 
-  MESSAGE(STATUS "Using Tesseract iOS framework: ${Tesseract_IOS_FRAMEWORK_PATH}")
-  MESSAGE(STATUS "Using Leptonica iOS framework: ${Leptonica_IOS_FRAMEWORK_PATH}")
+IF(Tesseract_FRAMEWORK_PATH AND Leptonica_FRAMEWORK_PATH) 
+  MESSAGE(STATUS "Using Tesseract iOS framework: ${Tesseract_FRAMEWORK_PATH}")
+  MESSAGE(STATUS "Using Leptonica iOS framework: ${Leptonica_FRAMEWORK_PATH}")
   # http://www.vtk.org/Wiki/CMake:HowToUseExistingOSXFrameworks
-  SET(Tesseract_LIBRARIES "${Tesseract_IOS_FRAMEWORK_PATH};${Leptonica_IOS_FRAMEWORK_PATH}")
-  SET(Tesseract_INCLUDE_DIRS "${Tesseract_IOS_FRAMEWORK_PATH}/Headers")
+  SET(Tesseract_LIBRARIES "${Tesseract_FRAMEWORK_PATH};${Leptonica_FRAMEWORK_PATH}")
+  SET(Tesseract_INCLUDE_DIRS "${Tesseract_FRAMEWORK_PATH}/Headers")
 ELSE()
   FIND_PACKAGE( Tesseract REQUIRED )
 ENDIF()
 
 include_directories(${Tesseract_INCLUDE_DIRS})
 
-IF(OpenCV_IOS_FRAMEWORK_PATH)
-  MESSAGE(STATUS "Using OpenCV iOS framework: ${OpenCV_IOS_FRAMEWORK_PATH}")
-  SET(OpenCV_INCLUDE_DIRS "${OpenCV_IOS_FRAMEWORK_PATH}/Headers")
-  SET(OpenCV_LIBS ${OpenCV_IOS_FRAMEWORK_PATH})
+IF(OpenCV_FRAMEWORK_PATH)
+  MESSAGE(STATUS "Using OpenCV iOS framework: ${OpenCV_FRAMEWORK_PATH}")
+  SET(OpenCV_INCLUDE_DIRS "${OpenCV_FRAMEWORK_PATH}/Headers")
+  SET(OpenCV_LIBS ${OpenCV_FRAMEWORK_PATH})
 
   # OpenCV's released framework has this disabled, so we must too.
   # http://stackoverflow.com/a/32710441/868173

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,18 +52,37 @@ IF (WIN32 AND WITH_DAEMON)
   SET(WITH_DAEMON OFF)
 ENDIF()
 
-FIND_PACKAGE( Tesseract REQUIRED )
+IF(Tesseract_IOS_FRAMEWORK_PATH AND Leptonica_IOS_FRAMEWORK_PATH) 
+  MESSAGE(STATUS "Using Tesseract iOS framework: ${Tesseract_IOS_FRAMEWORK_PATH}")
+  MESSAGE(STATUS "Using Leptonica iOS framework: ${Leptonica_IOS_FRAMEWORK_PATH}")
+  # http://www.vtk.org/Wiki/CMake:HowToUseExistingOSXFrameworks
+  SET(Tesseract_LIBRARIES "${Tesseract_IOS_FRAMEWORK_PATH};${Leptonica_IOS_FRAMEWORK_PATH}")
+  SET(Tesseract_INCLUDE_DIRS "${Tesseract_IOS_FRAMEWORK_PATH}/Headers")
+ELSE()
+  FIND_PACKAGE( Tesseract REQUIRED )
+ENDIF()
 
 include_directories(${Tesseract_INCLUDE_DIRS})
 
-# Discover OpenCV directory automatically
-find_path(OpenCV_DIR
-  NAMES OpenCVConfig.cmake
-  HINTS ${CMAKE_SOURCE_DIR}/../libraries/opencv/
-        /storage/projects/alpr/libraries/opencv/
-)
-# Opencv Package
-FIND_PACKAGE( OpenCV REQUIRED )
+IF(OpenCV_IOS_FRAMEWORK_PATH)
+  MESSAGE(STATUS "Using OpenCV iOS framework: ${OpenCV_IOS_FRAMEWORK_PATH}")
+  SET(OpenCV_INCLUDE_DIRS "${OpenCV_IOS_FRAMEWORK_PATH}/Headers")
+  SET(OpenCV_LIBS ${OpenCV_IOS_FRAMEWORK_PATH})
+
+  # OpenCV's released framework has this disabled, so we must too.
+  # http://stackoverflow.com/a/32710441/868173
+  SET(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE NO)
+ELSE()
+  # Discover OpenCV directory automatically
+  find_path(OpenCV_DIR
+    NAMES OpenCVConfig.cmake
+    HINTS ${CMAKE_SOURCE_DIR}/../libraries/opencv/
+    /storage/projects/alpr/libraries/opencv/
+    )
+  # Opencv Package
+  FIND_PACKAGE( OpenCV REQUIRED )
+ENDIF()
+
 IF (${OpenCV_VERSION} VERSION_LESS 2.4.7)
 	MESSAGE(FATAL_ERROR "OpenCV version is not compatible : ${OpenCV_VERSION}")
 ENDIF()
@@ -94,7 +113,9 @@ ENDIF()
 
 
 set(CMAKE_CSS_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall ")
-ADD_EXECUTABLE( alpr  main.cpp )
+if (NOT IOS)
+  ADD_EXECUTABLE( alpr  main.cpp )
+ENDIF()
 
 if (WIN32) 
    SET(OPENALPR_LIB openalpr-static)
@@ -102,15 +123,17 @@ ELSE()
    SET(OPENALPR_LIB openalpr)
 ENDIF()
 
-TARGET_LINK_LIBRARIES(alpr
-	${OPENALPR_LIB}
-	statedetection
-	support
+if (NOT IOS)
+  TARGET_LINK_LIBRARIES(alpr
+    ${OPENALPR_LIB}
+    statedetection
+    support
     video
-	${OpenCV_LIBS}
-	${Tesseract_LIBRARIES}
+    ${OpenCV_LIBS}
+    ${Tesseract_LIBRARIES}
     ${Extra_LIBS}
   )
+ENDIF()
 
 # Compile the alprd library on Unix-based OS
 IF (WITH_DAEMON)
@@ -149,8 +172,10 @@ if (WITH_BINDING_PYTHON)
 add_subdirectory(bindings/python)
 ENDIF()
 
-install (TARGETS    alpr DESTINATION   ${CMAKE_INSTALL_PREFIX}/bin)
-install (FILES      ${CMAKE_SOURCE_DIR}/../doc/man/alpr.1 DESTINATION       ${CMAKE_INSTALL_PREFIX}/share/man/man1 COMPONENT doc)
+if (NOT IOS)
+  install (TARGETS    alpr DESTINATION   ${CMAKE_INSTALL_PREFIX}/bin)
+  install (FILES      ${CMAKE_SOURCE_DIR}/../doc/man/alpr.1 DESTINATION       ${CMAKE_INSTALL_PREFIX}/share/man/man1 COMPONENT doc)
+ENDIF()
 install (DIRECTORY  ${CMAKE_SOURCE_DIR}/../runtime_data DESTINATION         ${CMAKE_INSTALL_PREFIX}/share/openalpr)
 
 # set runtime_data to reflect the current CMAKE_INSTALL_PREFIX

--- a/src/statedetection/CMakeLists.txt
+++ b/src/statedetection/CMakeLists.txt
@@ -8,7 +8,7 @@ set(statedetector_source_files
   state_detector_impl.cpp
 )
 
-if (WIN32) 
+if (WIN32 OR IOS) 
 	add_library(statedetection 		STATIC ${statedetector_source_files} )
 ELSE()
 	add_library(statedetection 		SHARED ${statedetector_source_files} )


### PR DESCRIPTION
Hi there,

I am not sure if this is the best approach for what I am trying to do, so feedback is welcome.  

For working with the 2.2.x version of alpr and later (which uses opencv 3), I have refactored the `openalpr-ios` project to use a script that will create a universal static iOS openalpr.framework bundle, and will include tesseract, leptonica, and opencv (3) frameworks (as opposed to the current process, which is partially manual).  The script will build openalpr with the aid of a [iOS toolchain file](https://github.com/twelve17/openalpr-ios/blob/2_0/etc/cmake/Toolchains/iOS.cmake), which, among other things, will set the `IOS` CMake variable to `TRUE`.

Along with the above, I am proposing these changes to a couple of the openalpr CMakeLists.txt files to help the two parts work together.

Basically, the changes are:
- Allow passing in `Tesseract_IOS_FRAMEWORK_PATH`, `Leptonica_IOS_FRAMEWORK_PATH`, and `OpenCV_IOS_FRAMEWORK_PATH` CMake cache values that alter how openalpr finds the headers and libraries for these dependencies.
- Omit build of the `alpr` executable and installation man files when `IOS` is true
- Build `statedetection` as a static library when `IOS` is true

You can see the updated `openalpr-ios` changes [on the `2_0` branch](https://github.com/twelve17/openalpr-ios/tree/2_0) if you are interested.