### PR TITLE
macports support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,18 +135,21 @@ if (NOT IOS)
   )
 ENDIF()
 
+
 # Compile the alprd library on Unix-based OS
 IF (WITH_DAEMON)
   ADD_EXECUTABLE( alprd  daemon.cpp daemon/beanstalk.c daemon/beanstalk.cc )
 
+  FIND_PACKAGE( log4cplus REQUIRED )
+
   TARGET_LINK_LIBRARIES(alprd
-	  openalpr
+      ${OPENALPR_LIB}
 	  support
       video
 	  curl
-	  log4cplus
 	  ${OpenCV_LIBS}
 	  ${Tesseract_LIBRARIES}
+	  ${log4cplus_LIBRARIES}
       ${Extra_LIBS}
     )
 	

--- a/src/cmake_modules/FindTesseract.cmake
+++ b/src/cmake_modules/FindTesseract.cmake
@@ -17,6 +17,8 @@ find_path(Tesseract_INCLUDE_BASEAPI_DIR
         "/usr/include/tesseract"
         "/usr/local/include"
         "/usr/local/include/tesseract"
+        "/opt/local/include"
+        "/opt/local/include/tesseract"
         ${Tesseract_PKGCONF_INCLUDE_DIRS}
 		${CMAKE_SOURCE_DIR}/../libraries/tesseract-ocr/api/
 )
@@ -26,6 +28,8 @@ find_path(Tesseract_INCLUDE_CCSTRUCT_DIR
         "/usr/include/tesseract"
         "/usr/local/include"
         "/usr/local/include/tesseract"
+        "/opt/local/include"
+        "/opt/local/include/tesseract"
         ${Tesseract_PKGCONF_INCLUDE_DIRS}
 		${CMAKE_SOURCE_DIR}/../libraries/tesseract-ocr/ccstruct/
 )
@@ -35,6 +39,8 @@ find_path(Tesseract_INCLUDE_CCMAIN_DIR
         "/usr/include/tesseract"
         "/usr/local/include"
         "/usr/local/include/tesseract"
+        "/opt/local/include"
+        "/opt/local/include/tesseract"
         ${Tesseract_PKGCONF_INCLUDE_DIRS}
 		${CMAKE_SOURCE_DIR}/../libraries/tesseract-ocr/ccmain/
 )
@@ -44,6 +50,8 @@ find_path(Tesseract_INCLUDE_CCUTIL_DIR
         "/usr/include/tesseract"
         "/usr/local/include"
         "/usr/local/include/tesseract"
+        "/opt/local/include"
+        "/opt/local/include/tesseract"
         ${Tesseract_PKGCONF_INCLUDE_DIRS}
 		${CMAKE_SOURCE_DIR}/../libraries/tesseract-ocr/ccutil/
 )
@@ -54,6 +62,7 @@ find_library(Tesseract_LIB
   NAMES tesseract tesseract-static libtesseract303-static
   HINTS "/usr/lib"
         "/usr/local/lib"
+        "/opt/local/lib"
         ${Tesseract_PKGCONF_LIBRARY_DIRS}
 		${CMAKE_SOURCE_DIR}/../libraries/tesseract-ocr/api/.libs
 		${CMAKE_SOURCE_DIR}/../libraries/tesseract-ocr/vs2010/LIB_Release
@@ -63,6 +72,7 @@ find_library(Leptonica_LIB
   NAMES liblept170 liblept lept
   HINTS "/usr/lib"
         "/usr/local/lib"
+        "/opt/local/lib"
         ${Tesseract_PKGCONF_LIBRARY_DIRS}
 		${CMAKE_SOURCE_DIR}/../libraries/tesseract-ocr/api/.libs
 		${CMAKE_SOURCE_DIR}/../libraries/tesseract-ocr/vs2010/LIB_Release

--- a/src/cmake_modules/Findlog4cplus.cmake
+++ b/src/cmake_modules/Findlog4cplus.cmake
@@ -1,0 +1,35 @@
+# - Try to find log4cplus
+# Once done, this will define
+#
+#  log4cplus_FOUND - system has log4cplus
+#  log4cplus_INCLUDE_DIRS - the log4cplus include directories
+#  log4cplus_LIBRARIES - link these to use log4cplus
+
+#libfind_pkg_check_modules(log4cplus_PKGCONF log4cplus)
+
+# Include dir
+find_path(log4cplus_INCLUDE_DIR
+  NAMES log4cplus/version.h
+  HINTS "/usr/include"
+        "/usr/include/log4cplus"
+        "/usr/local/include"
+        "/usr/local/include/log4cplus"
+        "/opt/local/include"
+        "/opt/local/include/log4cplus"
+        ${log4cplus_PKGCONF_INCLUDE_DIRS}
+)
+
+# Finally the library itself
+find_library(log4cplus_LIB
+  NAMES log4cplus liblog4cplus liblog4cplus-static
+  HINTS "/usr/lib"
+        "/usr/local/lib"
+        "/opt/local/lib"
+        ${log4cplus_PKGCONF_LIBRARY_DIRS}
+)
+
+set(log4cplus_PROCESS_INCLUDES log4cplus_INCLUDE_DIR)
+set(log4cplus_PROCESS_LIBS log4cplus_LIB)
+
+libfind_process(log4cplus)
+


### PR DESCRIPTION
I have built opemalpr on Mac using macports instead of break. Changes to the build process are as follows:

1. For Tesseract detection I've added /opt/local/ paths to search for includes and libraries

2. I have implemented log4cplus detection similarly to Tesseract via cmake module. Other platforms could also benefit from that. 

