### PR TITLE
Fix spelling in --seek option documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Where:
      Max number of possible plate numbers to return.  Default=10
 
    --seek <integer_ms>
-     Seek to the specied millisecond in a video file. Default=0
+     Seek to the specified millisecond in a video file. Default=0
 
    -p <pattern code>,  --pattern <pattern code>
      Attempt to match the plate number against a plate pattern (e.g., md

--- a/doc/man/alpr.1
+++ b/doc/man/alpr.1
@@ -44,7 +44,7 @@ Where:
      Max number of possible plate numbers to return.  Default=10
 
    \-\-seek <integer_ms>
-     Seek to the specied millisecond in a video file. Default=0
+     Seek to the specified millisecond in a video file. Default=0
 
    \-p <pattern code>,  \-\-pattern <pattern code>
      Attempt to match the plate number against a plate pattern (e.g., md

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,7 +70,7 @@ int main( int argc, const char** argv )
 
   
   TCLAP::ValueArg<std::string> countryCodeArg("c","country","Country code to identify (either us for USA or eu for Europe).  Default=us",false, "us" ,"country_code");
-  TCLAP::ValueArg<int> seekToMsArg("","seek","Seek to the specied millisecond in a video file. Default=0",false, 0 ,"integer_ms");
+  TCLAP::ValueArg<int> seekToMsArg("","seek","Seek to the specified millisecond in a video file. Default=0",false, 0 ,"integer_ms");
   TCLAP::ValueArg<std::string> configFileArg("","config","Path to the openalpr.conf file",false, "" ,"config_file");
   TCLAP::ValueArg<std::string> templatePatternArg("p","pattern","Attempt to match the plate number against a plate pattern (e.g., md for Maryland, ca for California)",false, "" ,"pattern code");
   TCLAP::ValueArg<int> topNArg("n","topn","Max number of possible plate numbers to return.  Default=10",false, 10 ,"topN");


### PR DESCRIPTION
Fix spelling specied -> specified in the description of the --seek command.
I updated the text in the actual --help output, and the README and manpage.