### PR TITLE
Finally getting rid of "OpenCV Error: Assertion failed (0 <= roi.x &&…

### DIFF
--- a/src/openalpr/utility.cpp
+++ b/src/openalpr/utility.cpp
@@ -40,18 +40,12 @@ namespace alpr
     expandedRegion.y = expandedRegion.y - halfY;
     expandedRegion.height =  expandedRegion.height + expandYPixels;
 
-    if (expandedRegion.x < 0)
-      expandedRegion.x = 0;
-    if (expandedRegion.y < 0)
-      expandedRegion.y = 0;
-    if (expandedRegion.x + expandedRegion.width > maxX)
+	expandedRegion.x = std::min(std::max(expandedRegion.x, 0), maxX);
+	expandedRegion.y = std::min(std::max(expandedRegion.y, 0), maxY);
+	if (expandedRegion.x + expandedRegion.width > maxX)
       expandedRegion.width = maxX - expandedRegion.x;
     if (expandedRegion.y + expandedRegion.height > maxY)
       expandedRegion.height = maxY - expandedRegion.y;
-    if (expandedRegion.width < 0)
-      expandedRegion.width = 0;
-    if (expandedRegion.height < 0)
-      expandedRegion.height = 0;
     
     return expandedRegion;
   }


### PR DESCRIPTION
Hi Math,
I still had some issues with assertion errors, especially when using motiondetection and Prewarp on video streams. Looking into this I think I found an error in expandRect. 
To avoid assertion errors expandedregion.x and expandregion.y should also be tested against maxX and maxY.
Kind regards,
Kees