### PR TITLE
fixed daemon crashing

### DIFF
--- a/src/openalpr/cjson.c
+++ b/src/openalpr/cjson.c
@@ -100,7 +100,7 @@ static const char *parse_number(cJSON *item,const char *num)
 	if (*num=='-') sign=-1,num++;	/* Has sign? */
 	if (*num=='0') num++;			/* is zero */
 	if (*num>='1' && *num<='9')	do	n=(n*10.0)+(*num++ -'0');	while (*num>='0' && *num<='9');	/* Number? */
-	if (*num=='.' && num[1]>='0' && num[1]<='9') {num++;		do	n=(n*10.0)+(*num++ -'0'),scale--; while (*num>='0' && *num<='9');}	/* Fractional part? */
+	if (*num=='.' || *num==','  && num[1]>='0' && num[1]<='9') {num++;		do	n=(n*10.0)+(*num++ -'0'),scale--; while (*num>='0' && *num<='9');}	/* Fractional part? */
 	if (*num=='e' || *num=='E')		/* Exponent? */
 	{	num++;if (*num=='+') num++;	else if (*num=='-') signsubscale=-1,num++;		/* With sign? */
 		while (*num>='0' && *num<='9') subscale=(subscale*10)+(*num++ - '0');	/* Number? */


### PR DESCRIPTION
Daemon was crashing when parsing decimal number from string. It didn't check if current processing char is comma while next character is number.
For example if it was parsing 123,4567 it would convert just 123 to number, and the ",456" would stay in num array what causes crashing.