### PR TITLE
Added read from piped standard input support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,7 +145,27 @@ int main( int argc, const char** argv )
   {
     std::string filename = filenames[i];
 
-    if (filename == "stdin")
+    if (filename == "-")
+    {
+      std::vector<uchar> data;
+      int c;
+
+      while ((c = fgetc(stdin)) != EOF)
+      {
+        data.push_back((uchar) c);
+      }
+
+      frame = cv::imdecode(cv::Mat(data), 1);
+      if (!frame.empty())
+      {
+        detectandshow(&alpr, frame, "", outputJson);
+      }
+      else
+      {
+        std::cerr << "Image invalid: " << filename << std::endl;
+      }
+    }
+    else if (filename == "stdin")
     {
       std::string filename;
       while (std::getline(std::cin, filename))


### PR DESCRIPTION
`alpr` can now receive an image from standard input (the binary content) like one of these (Note the ending `-` which tells `alpr` to read a binary content from the standard input):

```bash
$ wget -O- -q http://plates.openalpr.com/h786poj.jpg | alpr -
$ cat h786poj.jpg | alpr -
```