### PR TITLE
Set locale to avoid numeric conversion issues

### DIFF
--- a/src/openalpr/cjson.c
+++ b/src/openalpr/cjson.c
@@ -30,6 +30,7 @@
 #include <float.h>
 #include <limits.h>
 #include <ctype.h>
+#include <locale.h>
 #include "cjson.h"
 
 static const char *ep;
@@ -117,6 +118,9 @@ static const char *parse_number(cJSON *item,const char *num)
 /* Render the number nicely from the given item into a string. */
 static char *print_number(cJSON *item)
 {
+    char * locale = setlocale(LC_ALL, NULL);
+    setlocale(LC_NUMERIC, "C");
+
 	char *str;
 	double d=item->valuedouble;
 	if (fabs(((double)item->valueint)-d)<=DBL_EPSILON && d<=INT_MAX && d>=INT_MIN)
@@ -134,6 +138,8 @@ static char *print_number(cJSON *item)
 			else												sprintf(str,"%f",d);
 		}
 	}
+
+	setlocale(LC_NUMERIC, locale);
 	return str;
 }
 

--- a/src/openalpr/config_helper.cpp
+++ b/src/openalpr/config_helper.cpp
@@ -19,6 +19,7 @@
 
 #include "config_helper.h"
 
+#include <clocale>
 #include <iostream>
 
 using namespace std;
@@ -37,7 +38,13 @@ namespace alpr
       return defaultValue;
     }
 
+    char * locale = std::setlocale(LC_ALL, NULL);
+    setlocale(LC_NUMERIC, "C");
+
     float val = atof(pszValue);
+
+    std::setlocale(LC_NUMERIC, locale);
+
     return val;
   }
   
@@ -51,13 +58,18 @@ namespace alpr
     values.sort(CSimpleIniA::Entry::LoadOrder());
 
     std::vector<float> response;
-    
-  // output all of the items
+
+    char * locale = std::setlocale(LC_ALL, NULL);
+    std::setlocale(LC_NUMERIC, "C");
+
+      // output all of the items
     CSimpleIniA::TNamesDepend::const_iterator i;
-    for (i = values.begin(); i != values.end(); ++i) { 
+    for (i = values.begin(); i != values.end(); ++i) {
       response.push_back(atof(i->pItem));
     }
-    
+
+    std::setlocale(LC_NUMERIC, locale);
+
     return response;
   }
   


### PR DESCRIPTION
In certain locales decimal separator is comma instead of a dot.
Without this change OpenALPR will silently fail or produce
meaningless error from underlying OpenCV function.

Additionally json produced will not be valid.