### PR TITLE
Enhance interop with Java

### DIFF
--- a/src/bindings/java/com_openalpr_jni_Alpr.h
+++ b/src/bindings/java/com_openalpr_jni_Alpr.h
@@ -49,6 +49,14 @@ JNIEXPORT jstring JNICALL Java_com_openalpr_jni_Alpr_native_1recognize___3B
 
 /*
  * Class:     com_openalpr_jni_Alpr
+ * Method:    native_recognize
+ * Signature: (JIII)Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_com_openalpr_jni_Alpr_native_1recognize__JIII
+  (JNIEnv *, jobject, jlong, jint, jint, jint);
+
+/*
+ * Class:     com_openalpr_jni_Alpr
  * Method:    set_default_region
  * Signature: (Ljava/lang/String;)V
  */

--- a/src/bindings/java/openalprjni.cpp
+++ b/src/bindings/java/openalprjni.cpp
@@ -88,6 +88,24 @@ JNIEXPORT jstring JNICALL Java_com_openalpr_jni_Alpr_native_1recognize___3B
     return env->NewStringUTF(json.c_str());
   }
 
+JNIEXPORT jstring JNICALL Java_com_openalpr_jni_Alpr_native_1recognize__JIII
+  (JNIEnv *env, jobject thisObj, jlong data, jint bytesPerPixel, jint width, jint height)
+  {
+    //printf("Recognize data pointer");
+
+    AlprResults results = nativeAlpr->recognize(
+            reinterpret_cast<unsigned char*>(data),
+            static_cast<int>(bytesPerPixel),
+            static_cast<int>(width),
+            static_cast<int>(height),
+            std::vector<AlprRegionOfInterest>());
+
+    std::string json = Alpr::toJson(results);
+
+    return env->NewStringUTF(json.c_str());
+  }
+
+
 JNIEXPORT void JNICALL Java_com_openalpr_jni_Alpr_set_1default_1region
   (JNIEnv *env, jobject thisObj, jstring jdefault_region)
   {

--- a/src/bindings/java/src/com/openalpr/jni/Alpr.java
+++ b/src/bindings/java/src/com/openalpr/jni/Alpr.java
@@ -15,6 +15,7 @@ public class Alpr {
     private native boolean is_loaded();
     private native String native_recognize(String imageFile);
     private native String native_recognize(byte[] imageBytes);
+    private native String native_recognize(long imageData, int bytesPerPixel, int imgWidth, int imgHeight);
 
     private native void set_default_region(String region);
     private native void detect_region(boolean detectRegion);
@@ -54,6 +55,18 @@ public class Alpr {
     {
         try {
             String json = native_recognize(imageBytes);
+            return new AlprResults(json);
+        } catch (JSONException e)
+        {
+            throw new AlprException("Unable to parse ALPR results");
+        }
+    }
+
+
+    public AlprResults recognize(long imageData, int bytesPerPixel, int imgWidth, int imgHeight) throws AlprException
+    {
+        try {
+            String json = native_recognize(imageData, bytesPerPixel, imgWidth, imgHeight);
             return new AlprResults(json);
         } catch (JSONException e)
         {


### PR DESCRIPTION
When working with JVM based language and OpenCV you may have a ptr to
the native Mat data. This binding allows passing it to the OpenALPR.

Usage:
Mat mat = ...
alpr.recognize(mat.dataAddr(), mat.channels(), mat.width(), mat.height())