### PR TITLE
Update daemon default confguration to not start

### DIFF
--- a/distros/debian/openalpr-daemon.default
+++ b/distros/debian/openalpr-daemon.default
@@ -8,7 +8,9 @@
 # The options commented out show the default values.
 
 # Start the daemon if set to "yes"
-START_DAEMON="yes"
+# preset to "no" per default as it kills ssd's and flash memories with warn and info logs
+# without clear install time warnings send to user installing openalpr
+START_DAEMON="no"
 
 # Path to the log file
 #LOGFILE="/var/log/alpr.log"


### PR DESCRIPTION
If the webcam is not properly configured, default daemon's configuration generates recurrent logs of warnings and infos.
This fills up the log file very fast and kills the expected life time of ssd's and sdcard's used for /var/log.

So this is just a suggestion or quick fix as more underlying problems exist:
a- no install time message is provided to user who ignores the daemon's existence and uncomplete configuration.
b- log file grows up for ever unless logrotate does the job of course, but that doesn't seems to be the case