### PR TITLE
Recognize numpy image

### DIFF
--- a/src/bindings/python/openalpr/openalpr.py
+++ b/src/bindings/python/openalpr/openalpr.py
@@ -176,7 +176,9 @@ class Alpr():
         :return: An OpenALPR analysis in the form of a response dictionary
         """
         img = img.astype(np.ubyte)
-        ptr = self._recognize_image_func(self.alpr_pointer, img, img.shape[1], img.shape[0])
+        # deal with gray scale images
+        dims = 3 if len(img.shape) == 3 else 1
+        ptr = self._recognize_image_func(self.alpr_pointer, img, img.shape[1], img.shape[0], dims)
         json_data = ctypes.cast(ptr, ctypes.c_char_p).value
         json_data = _convert_from_charp(json_data)
         response_obj = json.loads(json_data)

--- a/src/bindings/python/openalpr/openalpr.py
+++ b/src/bindings/python/openalpr/openalpr.py
@@ -172,11 +172,11 @@ class Alpr():
         """
         This causes OpenALPR to attempt to recognize an image passed in as a numpy array.
 
-        :param img: This should be a 3d numpy array
+        :param img: This should be a 2d or 3d numpy array (gray scale or rgb image)
         :return: An OpenALPR analysis in the form of a response dictionary
         """
         img = img.astype(np.ubyte)
-        # deal with gray scale  and rgb images
+        # deal with gray scale and rgb images
         dims = 3 if len(img.shape) == 3 else 1
         ptr = self._recognize_image_func(self.alpr_pointer, img, img.shape[1], img.shape[0], dims)
         json_data = ctypes.cast(ptr, ctypes.c_char_p).value

--- a/src/bindings/python/openalpr/openalpr.py
+++ b/src/bindings/python/openalpr/openalpr.py
@@ -176,7 +176,7 @@ class Alpr():
         :return: An OpenALPR analysis in the form of a response dictionary
         """
         img = img.astype(np.ubyte)
-        # deal with gray scale images
+        # deal with gray scale  and rgb images
         dims = 3 if len(img.shape) == 3 else 1
         ptr = self._recognize_image_func(self.alpr_pointer, img, img.shape[1], img.shape[0], dims)
         json_data = ctypes.cast(ptr, ctypes.c_char_p).value

--- a/src/bindings/python/openalpr/openalpr.py
+++ b/src/bindings/python/openalpr/openalpr.py
@@ -1,6 +1,8 @@
 import ctypes
 import json
 import platform
+import numpy as np
+from numpy.ctypeslib import ndpointer
 
 # We need to do things slightly differently for Python 2 vs. 3
 # ... because the way str/unicode have changed to bytes/str
@@ -75,6 +77,15 @@ class Alpr():
         self._recognize_array_func = self._openalprpy_lib.recognizeArray
         self._recognize_array_func.restype = ctypes.c_void_p
         self._recognize_array_func.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_ubyte), ctypes.c_uint]
+
+        self._recognize_image_func = self._openalprpy_lib.recognizeImage
+        self._recognize_image_func.restype = ctypes.c_void_p
+        self._recognize_image_func.argtypes = [
+            ctypes.c_void_p,
+            ndpointer(ctypes.c_ubyte, flags="CONTIGUOUS"),
+            ctypes.c_uint,
+            ctypes.c_uint
+        ]
 
         self._free_json_mem_func = self._openalprpy_lib.freeJsonMem
 
@@ -151,6 +162,21 @@ class Alpr():
             raise TypeError("Expected a byte array (string in Python 2, bytes in Python 3)")
         pb = ctypes.cast(byte_array, ctypes.POINTER(ctypes.c_ubyte))
         ptr = self._recognize_array_func(self.alpr_pointer, pb, len(byte_array))
+        json_data = ctypes.cast(ptr, ctypes.c_char_p).value
+        json_data = _convert_from_charp(json_data)
+        response_obj = json.loads(json_data)
+        self._free_json_mem_func(ctypes.c_void_p(ptr))
+        return response_obj
+
+    def recognize_image(self, img):
+        """
+        This causes OpenALPR to attempt to recognize an image passed in as a numpy array.
+
+        :param img: This should be a 3d numpy array
+        :return: An OpenALPR analysis in the form of a response dictionary
+        """
+        img = img.astype(np.ubyte)
+        ptr = self._recognize_image_func(self.alpr_pointer, img, img.shape[1], img.shape[0])
         json_data = ctypes.cast(ptr, ctypes.c_char_p).value
         json_data = _convert_from_charp(json_data)
         response_obj = json.loads(json_data)

--- a/src/bindings/python/openalpr/openalpr.py
+++ b/src/bindings/python/openalpr/openalpr.py
@@ -177,8 +177,8 @@ class Alpr():
         """
         img = img.astype(np.ubyte)
         # deal with gray scale and rgb images
-        dims = 3 if len(img.shape) == 3 else 1
-        ptr = self._recognize_image_func(self.alpr_pointer, img, img.shape[1], img.shape[0], dims)
+        depth = 3 if len(img.shape) == 3 else 1
+        ptr = self._recognize_image_func(self.alpr_pointer, img, img.shape[1], img.shape[0], depth)
         json_data = ctypes.cast(ptr, ctypes.c_char_p).value
         json_data = _convert_from_charp(json_data)
         response_obj = json.loads(json_data)

--- a/src/bindings/python/openalprpy.cpp
+++ b/src/bindings/python/openalprpy.cpp
@@ -96,6 +96,25 @@ extern "C" {
       return membuffer;
     }
 
+  OPENALPR_EXPORT char* recognizeImage(Alpr* nativeAlpr, unsigned char *buf, int width, int height)
+      {
+        //printf("Recognize byte array");
+        //printf("buffer pointer: %p\n", buf);
+        //printf("buffer length: %d\n", len);
+
+        //std::cout << "Using instance: " << nativeAlpr << std::endl;
+
+        AlprResults results = nativeAlpr->recognize(buf, width, height);
+        std::string json = Alpr::toJson(results);
+
+        int strsize = sizeof(char) * (strlen(json.c_str()) + 1);
+        char* membuffer = (char*)malloc(strsize);
+        strcpy(membuffer, json.c_str());
+        //printf("allocated address: %p\n", membuffer);
+
+        return membuffer;
+      }
+
   OPENALPR_EXPORT void setCountry(Alpr* nativeAlpr, char* ccountry)
     {
       // Convert strings from java to C++ and release resources

--- a/src/bindings/python/openalprpy.cpp
+++ b/src/bindings/python/openalprpy.cpp
@@ -98,19 +98,12 @@ extern "C" {
 
   OPENALPR_EXPORT char* recognizeImage(Alpr* nativeAlpr, unsigned char *buf, int width, int height, int depth)
       {
-        //printf("Recognize byte array");
-        //printf("buffer pointer: %p\n", buf);
-        //printf("buffer length: %d\n", len);
-
-        //std::cout << "Using instance: " << nativeAlpr << std::endl;
-
         AlprResults results = nativeAlpr->recognize(buf, width, height, depth);
         std::string json = Alpr::toJson(results);
 
         int strsize = sizeof(char) * (strlen(json.c_str()) + 1);
         char* membuffer = (char*)malloc(strsize);
         strcpy(membuffer, json.c_str());
-        //printf("allocated address: %p\n", membuffer);
 
         return membuffer;
       }

--- a/src/bindings/python/openalprpy.cpp
+++ b/src/bindings/python/openalprpy.cpp
@@ -96,7 +96,7 @@ extern "C" {
       return membuffer;
     }
 
-  OPENALPR_EXPORT char* recognizeImage(Alpr* nativeAlpr, unsigned char *buf, int width, int height)
+  OPENALPR_EXPORT char* recognizeImage(Alpr* nativeAlpr, unsigned char *buf, int width, int height, int depth)
       {
         //printf("Recognize byte array");
         //printf("buffer pointer: %p\n", buf);
@@ -104,7 +104,7 @@ extern "C" {
 
         //std::cout << "Using instance: " << nativeAlpr << std::endl;
 
-        AlprResults results = nativeAlpr->recognize(buf, width, height);
+        AlprResults results = nativeAlpr->recognize(buf, width, height, depth);
         std::string json = Alpr::toJson(results);
 
         int strsize = sizeof(char) * (strlen(json.c_str()) + 1);

--- a/src/bindings/python/test.py
+++ b/src/bindings/python/test.py
@@ -1,3 +1,4 @@
+import cv2
 from openalpr import Alpr
 from argparse import ArgumentParser
 
@@ -50,7 +51,43 @@ try:
 
                 print("  %s %12s%12f" % (prefix, candidate['plate'], candidate['confidence']))
 
+finally:
+    if alpr:
+        alpr.unload()
 
+
+try:
+    alpr = Alpr(options.country, options.config, options.runtime_data)
+
+    if not alpr.is_loaded():
+        print("Error loading OpenALPR")
+    else:
+        print("Using OpenALPR " + alpr.get_version())
+
+        alpr.set_top_n(7)
+        alpr.set_default_region("wa")
+        alpr.set_detect_region(False)
+        img = cv2.imread(options.plate_image)
+        results = alpr.recognize_image(img)
+
+        # Uncomment to see the full results structure
+        # import pprint
+        # pprint.pprint(results)
+
+        print("Image size: %dx%d" %(results['img_width'], results['img_height']))
+        print("Processing Time: %f" % results['processing_time_ms'])
+
+        i = 0
+        for plate in results['results']:
+            i += 1
+            print("Plate #%d" % i)
+            print("   %12s %12s" % ("Plate", "Confidence"))
+            for candidate in plate['candidates']:
+                prefix = "-"
+                if candidate['matches_template']:
+                    prefix = "*"
+
+                print("  %s %12s%12f" % (prefix, candidate['plate'], candidate['confidence']))
 
 finally:
     if alpr:

--- a/src/bindings/python/test_bytes_array.py
+++ b/src/bindings/python/test_bytes_array.py
@@ -1,0 +1,58 @@
+"""
+Test OpenAlpr by passing an image as a bytes array
+"""
+from openalpr import Alpr
+from argparse import ArgumentParser
+
+parser = ArgumentParser(description='OpenALPR Python Test Program')
+
+parser.add_argument("-c", "--country", dest="country", action="store", default="us",
+                  help="License plate Country" )
+
+parser.add_argument("--config", dest="config", action="store", default="/etc/openalpr/openalpr.conf",
+                  help="Path to openalpr.conf config file" )
+
+parser.add_argument("--runtime_data", dest="runtime_data", action="store", default="/usr/share/openalpr/runtime_data",
+                  help="Path to OpenALPR runtime_data directory" )
+
+parser.add_argument('plate_image', help='License plate image file')
+
+options = parser.parse_args()
+
+alpr = None
+try:
+    alpr = Alpr(options.country, options.config, options.runtime_data)
+
+    if not alpr.is_loaded():
+        print("Error loading OpenALPR")
+    else:
+        print("Using OpenALPR " + alpr.get_version())
+
+        alpr.set_top_n(7)
+        alpr.set_default_region("wa")
+        alpr.set_detect_region(False)
+        jpeg_bytes = open(options.plate_image, "rb").read()
+        results = alpr.recognize_array(jpeg_bytes)
+
+        # Uncomment to see the full results structure
+        # import pprint
+        # pprint.pprint(results)
+
+        print("Image size: %dx%d" %(results['img_width'], results['img_height']))
+        print("Processing Time: %f" % results['processing_time_ms'])
+
+        i = 0
+        for plate in results['results']:
+            i += 1
+            print("Plate #%d" % i)
+            print("   %12s %12s" % ("Plate", "Confidence"))
+            for candidate in plate['candidates']:
+                prefix = "-"
+                if candidate['matches_template']:
+                    prefix = "*"
+
+                print("  %s %12s%12f" % (prefix, candidate['plate'], candidate['confidence']))
+
+finally:
+    if alpr:
+        alpr.unload()

--- a/src/bindings/python/test_image.py
+++ b/src/bindings/python/test_image.py
@@ -1,3 +1,7 @@
+"""
+Test OpenAlpr by passing an image as A numpy array using OpenCV
+"""
+
 import cv2
 from openalpr import Alpr
 from argparse import ArgumentParser
@@ -5,56 +9,19 @@ from argparse import ArgumentParser
 parser = ArgumentParser(description='OpenALPR Python Test Program')
 
 parser.add_argument("-c", "--country", dest="country", action="store", default="us",
-                  help="License plate Country" )
+                    help="License plate Country" )
 
 parser.add_argument("--config", dest="config", action="store", default="/etc/openalpr/openalpr.conf",
-                  help="Path to openalpr.conf config file" )
+                    help="Path to openalpr.conf config file" )
 
 parser.add_argument("--runtime_data", dest="runtime_data", action="store", default="/usr/share/openalpr/runtime_data",
-                  help="Path to OpenALPR runtime_data directory" )
+                    help="Path to OpenALPR runtime_data directory" )
 
 parser.add_argument('plate_image', help='License plate image file')
 
 options = parser.parse_args()
 
 alpr = None
-try:
-    alpr = Alpr(options.country, options.config, options.runtime_data)
-
-    if not alpr.is_loaded():
-        print("Error loading OpenALPR")
-    else:
-        print("Using OpenALPR " + alpr.get_version())
-
-        alpr.set_top_n(7)
-        alpr.set_default_region("wa")
-        alpr.set_detect_region(False)
-        jpeg_bytes = open(options.plate_image, "rb").read()
-        results = alpr.recognize_array(jpeg_bytes)
-
-        # Uncomment to see the full results structure
-        # import pprint
-        # pprint.pprint(results)
-
-        print("Image size: %dx%d" %(results['img_width'], results['img_height']))
-        print("Processing Time: %f" % results['processing_time_ms'])
-
-        i = 0
-        for plate in results['results']:
-            i += 1
-            print("Plate #%d" % i)
-            print("   %12s %12s" % ("Plate", "Confidence"))
-            for candidate in plate['candidates']:
-                prefix = "-"
-                if candidate['matches_template']:
-                    prefix = "*"
-
-                print("  %s %12s%12f" % (prefix, candidate['plate'], candidate['confidence']))
-
-finally:
-    if alpr:
-        alpr.unload()
-
 
 try:
     alpr = Alpr(options.country, options.config, options.runtime_data)

--- a/src/openalpr/alpr.cpp
+++ b/src/openalpr/alpr.cpp
@@ -68,6 +68,12 @@ namespace alpr
     return impl->recognize(imageBytes);
   }
 
+  AlprResults Alpr::recognize(unsigned char *image, int width, int height)
+  {
+    cv::Size size = cv::Size(width, height);
+    return impl->recognize(image, size);
+  }
+
   AlprResults Alpr::recognize(std::vector<char> imageBytes, std::vector<AlprRegionOfInterest> regionsOfInterest)
   {
 	  return impl->recognize(imageBytes, regionsOfInterest);

--- a/src/openalpr/alpr.cpp
+++ b/src/openalpr/alpr.cpp
@@ -68,10 +68,9 @@ namespace alpr
     return impl->recognize(imageBytes);
   }
 
-  AlprResults Alpr::recognize(unsigned char *image, int width, int height)
+  AlprResults Alpr::recognize(unsigned char *image, int width, int height, int depth)
   {
-    cv::Size size = cv::Size(width, height);
-    return impl->recognize(image, size);
+    return impl->recognize(image, width, height, depth);
   }
 
   AlprResults Alpr::recognize(std::vector<char> imageBytes, std::vector<AlprRegionOfInterest> regionsOfInterest)

--- a/src/openalpr/alpr.h
+++ b/src/openalpr/alpr.h
@@ -156,7 +156,7 @@ namespace alpr
 	  AlprResults recognize(std::vector<char> imageBytes);
 
 	  // Recognize unsigned char representing an image.
-      AlprResults recognize(unsigned char *image, int width, int height);
+      AlprResults recognize(unsigned char *image, int width, int height, int depth);
 
 	  // Recognize from byte data representing an encoded image (e.g., BMP, PNG, JPG, GIF etc).
 	  AlprResults recognize(std::vector<char> imageBytes, std::vector<AlprRegionOfInterest> regionsOfInterest);

--- a/src/openalpr/alpr.h
+++ b/src/openalpr/alpr.h
@@ -155,7 +155,7 @@ namespace alpr
 	  // Recognize from byte data representing an encoded image (e.g., BMP, PNG, JPG, GIF etc).
 	  AlprResults recognize(std::vector<char> imageBytes);
 
-	  // Recognize from unsigned char * representing an image.
+      // Recognize from unsigned char * representing an image.
       AlprResults recognize(unsigned char *image, int width, int height, int depth);
 
 	  // Recognize from byte data representing an encoded image (e.g., BMP, PNG, JPG, GIF etc).

--- a/src/openalpr/alpr.h
+++ b/src/openalpr/alpr.h
@@ -155,6 +155,9 @@ namespace alpr
 	  // Recognize from byte data representing an encoded image (e.g., BMP, PNG, JPG, GIF etc).
 	  AlprResults recognize(std::vector<char> imageBytes);
 
+	  // Recognize unsigned char representing an image.
+      AlprResults recognize(unsigned char *image, int width, int height);
+
 	  // Recognize from byte data representing an encoded image (e.g., BMP, PNG, JPG, GIF etc).
 	  AlprResults recognize(std::vector<char> imageBytes, std::vector<AlprRegionOfInterest> regionsOfInterest);
 

--- a/src/openalpr/alpr.h
+++ b/src/openalpr/alpr.h
@@ -155,7 +155,7 @@ namespace alpr
 	  // Recognize from byte data representing an encoded image (e.g., BMP, PNG, JPG, GIF etc).
 	  AlprResults recognize(std::vector<char> imageBytes);
 
-	  // Recognize unsigned char representing an image.
+	  // Recognize from unsigned char * representing an image.
       AlprResults recognize(unsigned char *image, int width, int height, int depth);
 
 	  // Recognize from byte data representing an encoded image (e.g., BMP, PNG, JPG, GIF etc).

--- a/src/openalpr/alpr_impl.cpp
+++ b/src/openalpr/alpr_impl.cpp
@@ -420,11 +420,16 @@ namespace alpr
     }
   }
 
-  AlprResults AlprImpl::recognize( unsigned char *image, cv::Size size)
+  AlprResults AlprImpl::recognize( unsigned char *image, int width, int height, int depth)
     {
       try
       {
-        cv::Mat img = Mat(size, CV_8UC3, image);
+        cv::Mat img;
+        cv::Size size = cv::Size(width, height);
+        if(depth == 1)
+          img = Mat(size, CV_8UC1, image);
+        else if(depth == 3)
+          img = Mat(size, CV_8UC3, image);
         return this->recognize(img);
       }
       catch (cv::Exception& e)

--- a/src/openalpr/alpr_impl.cpp
+++ b/src/openalpr/alpr_impl.cpp
@@ -420,6 +420,21 @@ namespace alpr
     }
   }
 
+  AlprResults AlprImpl::recognize( unsigned char *image, cv::Size size)
+    {
+      try
+      {
+        cv::Mat img = Mat(size, CV_8UC3, image);
+        return this->recognize(img);
+      }
+      catch (cv::Exception& e)
+      {
+        std::cerr << "Caught exception in OpenALPR recognize: " << e.msg << std::endl;
+        AlprResults emptyresults;
+        return emptyresults;
+      }
+    }
+
   AlprResults AlprImpl::recognize(std::vector<char> imageBytes, std::vector<AlprRegionOfInterest> regionsOfInterest)
   {
     try

--- a/src/openalpr/alpr_impl.h
+++ b/src/openalpr/alpr_impl.h
@@ -83,6 +83,7 @@ namespace alpr
       AlprFullDetails recognizeFullDetails(cv::Mat img, std::vector<cv::Rect> regionsOfInterest);
 
       AlprResults recognize( std::vector<char> imageBytes );
+      AlprResults recognize( unsigned char *image, cv::Size size);
       AlprResults recognize( std::vector<char> imageBytes, std::vector<AlprRegionOfInterest> regionsOfInterest );
       AlprResults recognize( unsigned char* pixelData, int bytesPerPixel, int imgWidth, int imgHeight, std::vector<AlprRegionOfInterest> regionsOfInterest );
       AlprResults recognize( cv::Mat img );

--- a/src/openalpr/alpr_impl.h
+++ b/src/openalpr/alpr_impl.h
@@ -83,7 +83,7 @@ namespace alpr
       AlprFullDetails recognizeFullDetails(cv::Mat img, std::vector<cv::Rect> regionsOfInterest);
 
       AlprResults recognize( std::vector<char> imageBytes );
-      AlprResults recognize( unsigned char *image, cv::Size size);
+      AlprResults recognize( unsigned char *image, int width, int height, int depth);
       AlprResults recognize( std::vector<char> imageBytes, std::vector<AlprRegionOfInterest> regionsOfInterest );
       AlprResults recognize( unsigned char* pixelData, int bytesPerPixel, int imgWidth, int imgHeight, std::vector<AlprRegionOfInterest> regionsOfInterest );
       AlprResults recognize( cv::Mat img );


### PR DESCRIPTION
**Goal**
The OpenALPR Python binding interface currently only has a couple of methods in the binding to process images for number plate recognition. The provided methods either take a file to an image or an array of bytes which represent a jpeg image. It would be great to be able to pass in an OpenCV image (numpy array) so that the conversion to JPEG from numpy would not be required.

**Change**
include a new method that takes a numpy array and performs a number plate recognition 