### PR TITLE
Refactor: the method "cleanCharRegions" in Class "CharacterSegmenter"

### DIFF
--- a/src/openalpr/ocr/segmentation/charactersegmenter.h
+++ b/src/openalpr/ocr/segmentation/charactersegmenter.h
@@ -76,7 +76,7 @@ namespace alpr
 
       std::vector<cv::Rect> get1DHits(cv::Mat img, int yOffset);
 
-      void cleanCharRegions(std::vector<cv::Mat> thresholds, std::vector<cv::Rect> charRegions);
+      void cleanCharRegions(std::vector<cv::Mat> thresholds, std::vector<std::vector<cv::Rect> > & charRegions);
       void cleanBasedOnColor(std::vector<cv::Mat> thresholds, cv::Mat colorMask, std::vector<cv::Rect> charRegions);
       std::vector<cv::Rect> filterMostlyEmptyBoxes(std::vector<cv::Mat> thresholds, const  std::vector<cv::Rect> charRegions);
       cv::Mat filterEdgeBoxes(std::vector<cv::Mat> thresholds, const std::vector<cv::Rect> charRegions, float avgCharWidth, float avgCharHeight);


### PR DESCRIPTION
Cleaning characters that are too small in "charRegions", just remove them from pipeline_data, rather than fill the charRegions with black color.
	modified:   src/openalpr/ocr/segmentation/charactersegmenter.cpp
	modified:   src/openalpr/ocr/segmentation/charactersegmenter.h