### PR TITLE
Travis: Run `alpr` on H786POJ and EA7THE plates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ script:
   - make openalpr-utils-classifychars openalpr-utils-tagplates openalpr-utils-benchmark openalpr-utils-prepcharsfortraining
   - sudo make install
   - ./tests/unittests
+  - wget http://plates.openalpr.com/h786poj.jpg && alpr -c eu h786poj.jpg
+  - wget http://plates.openalpr.com/ea7the.jpg && alpr -c us ea7the.jpg
 
 
 


### PR DESCRIPTION
This doesn't check the output yet, but is a step towards having proper
integration tests, which can help us more effectively evaluate the
impact of changes like https://github.com/openalpr/openalpr/pull/690
(see https://github.com/openalpr/openalpr/issues/706).