### PR TITLE
More detailed pattern matching for GB plates

### DIFF
--- a/runtime_data/postprocess/gb.patterns
+++ b/runtime_data/postprocess/gb.patterns
@@ -1,1 +1,33 @@
-gb	@@##@@@
+gb	[A-HK-PR-TV-Y][A-HJ-PRSTV-Y]##[A-HJ-NPR-Z][A-HJ-NPR-Z][A-HJ-NPR-Z]
+
+gb	[A-HJ-NP-TV-Y]#[A-HJ-NPRSTV-Y][A-HJ-NPRSTV-Y][A-HJ-NPRSTV-Y]
+gb	[A-HJ-NP-TV-Y]##[A-HJ-NPRSTV-Y][A-HJ-NPRSTV-Y][A-HJ-NPRSTV-Y]
+gb	[A-HJ-NP-TV-Y]###[A-HJ-NPRSTV-Y][A-HJ-NPRSTV-Y][A-HJ-NPRSTV-Y]
+
+gb	[A-HJ-NPRSTV-Y][A-HJ-NPRSTV-Y][A-HJ-NPRSTV-Y]#[A-HJ-NP-TV-Y]
+gb	[A-HJ-NPRSTV-Y][A-HJ-NPRSTV-Y][A-HJ-NPRSTV-Y]#[A-HJ-NP-TV-Y]
+gb	[A-HJ-NPRSTV-Y][A-HJ-NPRSTV-Y][A-HJ-NPRSTV-Y]#[A-HJ-NP-TV-Y]
+
+gb	###[A-HJ-PR-Y][A-HJ-PR-Y][A-HJ-PR-Y]
+gb	##[A-HJ-PR-Y][A-HJ-PR-Y][A-HJ-PR-Y]
+gb	#[A-HJ-PR-Y][A-HJ-PR-Y][A-HJ-PR-Y]
+gb	####[A-HJ-PR-Y][A-HJ-PR-Y]
+gb	###[A-HJ-PR-Y][A-HJ-PR-Y]
+gb	##[A-HJ-PR-Y][A-HJ-PR-Y]
+gb	#[A-HJ-PR-Y][A-HJ-PR-Y]
+gb	####[A-HJ-PR-Y]
+gb	###[A-HJ-PR-Y]
+gb	##[A-HJ-PR-Y]
+gb	#[A-HJ-PR-Y]
+gb	[A-HJ-PR-Y][A-HJ-PR-Y]####
+gb	[A-HJ-PR-Y][A-HJ-PR-Y]###
+gb	[A-HJ-PR-Y][A-HJ-PR-Y]##
+gb	[A-HJ-PR-Y][A-HJ-PR-Y]#
+gb	[A-HJ-PR-Y]####
+gb	[A-HJ-PR-Y]###
+gb	[A-HJ-PR-Y]##
+gb	[A-HJ-PR-Y]#
+gb	[A-PR-Y][A-PR-Y][A-PR-Z]#### 
+gb	[A-PR-Y][A-PR-Y][A-PR-Z]###
+gb	[A-PR-Y][A-PR-Y][A-PR-Z]##
+gb	[A-PR-Y][A-PR-Y][A-PR-Z]#


### PR DESCRIPTION
Catering for the following:
 Current style (i.e. AB02ABC, CD12CDE, EF56GHJ, etc)
 Prefix style (i.e. A1ABC, B21BCD, C345DEF, etc)
 Suffix style (i.e. ABC1X, DEF21R, GHJ345W, etc)
 Dateless/Irish (i.e ABC123, 123ABC, 12ABC, IBZ1234, 23DF, etc)

ref: https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_the_United_Kingdom