### PR TITLE
Proposing a change to in.conf

### DIFF
--- a/runtime_data/config/in.conf
+++ b/runtime_data/config/in.conf
@@ -33,11 +33,11 @@ min_plate_size_width_px = 95
 min_plate_size_height_px = 20
 
 ; Results with fewer or more characters will be discarded
-postprocess_min_characters = 10
+postprocess_min_characters = 7
 postprocess_max_characters = 20
 
 ;ocr_language = lin
-ocr_language = lus
+ocr_language = leu
 
 ; Override for postprocess letters/numbers regex. 
 postprocess_regex_letters = [A-Z]


### PR DESCRIPTION
Proposed change to in.conf
there are many license plates in India which have less than 10 characters for eg. TN06H7223
this plate has only 9 characters and when I ran openalpr on the image it returned 'no plates found' for the current version of in.conf
however when I made the changes above it returned the correct answers
Plates in India can have number of letters as low as 7 so that is the reason why I have put postprocess_min_characters = 7
Also when I tested 200 sample images on indian cars i found that ocr language of leu gave more confident results than when ocr language was lus.
so proposing a change of lus to leu
here is a picture to demonstrate
![car2output](https://user-images.githubusercontent.com/48888068/60676724-3ce1dd00-9e9d-11e9-9a05-578c843db8ce.png)
