### PR TITLE
Port to OpenCV 4

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -253,7 +253,7 @@ int main( int argc, const char** argv )
 
         cv::VideoCapture cap = cv::VideoCapture();
         cap.open(filename);
-        cap.set(CV_CAP_PROP_POS_MSEC, seektoms);
+        cap.set(cv::CAP_PROP_POS_MSEC, seektoms);
 
         while (cap.read(frame))
         {

--- a/src/misc_utilities/binarizefontsheet.cpp
+++ b/src/misc_utilities/binarizefontsheet.cpp
@@ -71,7 +71,7 @@ bool sort_lined_rectangles(Rect i, Rect j) {
 void show_debug_image(vector<Rect> rectangles, Mat img)
 {
     Mat debugImg;
-    cvtColor(img, debugImg, CV_GRAY2BGR);
+    cvtColor(img, debugImg, COLOR_GRAY2BGR);
     for (unsigned int i = 0; i < rectangles.size(); i++)
     {
       Rect mr = rectangles[i];
@@ -172,7 +172,7 @@ int main(int argc, char** argv) {
 
     Config config("us");
     
-    cvtColor(frame, frame, CV_BGR2GRAY);
+    cvtColor(frame, frame, COLOR_BGR2GRAY);
     vector<Mat> thresholds = produceThresholds(frame, &config);
     
     
@@ -186,7 +186,7 @@ int main(int argc, char** argv) {
       
       vector<vector<Point> > speckle_contours;
       vector<Vec4i> speckle_hierarchy;
-      findContours(speckle_copy, speckle_contours, speckle_hierarchy, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_SIMPLE);
+      findContours(speckle_copy, speckle_contours, speckle_hierarchy, RETR_EXTERNAL, CHAIN_APPROX_SIMPLE);
       Mat testImg = Mat::zeros(thresholds[t].size(), thresholds[t].type());
       
       for (unsigned int i = 0; i < speckle_contours.size(); i++)
@@ -195,8 +195,8 @@ int main(int argc, char** argv) {
 
         if (speckleRect.area() < MIN_SPECKLE_AREA_PIXELS)
         {
-          drawContours(thresholds[t], speckle_contours, i, Scalar(0,0,0), CV_FILLED);
-          drawContours(testImg, speckle_contours, i, Scalar(255,255,255), CV_FILLED);
+          drawContours(thresholds[t], speckle_contours, i, Scalar(0,0,0), FILLED);
+          drawContours(testImg, speckle_contours, i, Scalar(255,255,255), FILLED);
         }
       }
       resize(testImg, testImg, Size(700, 1000));
@@ -220,7 +220,7 @@ int main(int argc, char** argv) {
       
       vector<vector<Point> > contours;
       vector<Vec4i> hierarchy;
-      findContours(blobby, contours, hierarchy, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_SIMPLE);
+      findContours(blobby, contours, hierarchy, RETR_EXTERNAL, CHAIN_APPROX_SIMPLE);
 
       bitwise_not(thresholds[t], thresholds[t]);
 

--- a/src/misc_utilities/calibrate.cpp
+++ b/src/misc_utilities/calibrate.cpp
@@ -230,7 +230,7 @@ void initialize_variables()
 
 void create_window()
 {
-  namedWindow(WINDOW_NAME, CV_WINDOW_AUTOSIZE | CV_WINDOW_KEEPRATIO | CV_GUI_EXPANDED);
+  namedWindow(WINDOW_NAME, WINDOW_AUTOSIZE | WINDOW_KEEPRATIO | WINDOW_GUI_EXPANDED);
   
   value = round(-(rotationx * 20000.0) + 100);
   createTrackbar( "X", WINDOW_NAME, &value, 200,  XChange);
@@ -400,8 +400,8 @@ int main(int argc, char** argv) {
   create_window();
   
   drawImage(imgOriginal);
-
-  while (cvGetWindowHandle(WINDOW_NAME.c_str()) != 0)
+/* //TODO: Port this to OpenCV 4
+  while (getWindowHandle(WINDOW_NAME.c_str()) != 0)
   {
 
     char c = waitKey(15);
@@ -416,8 +416,8 @@ int main(int argc, char** argv) {
     }
 
   }
-
-  cvDestroyAllWindows();
+*/
+  destroyAllWindows();
   
   
   return 0;

--- a/src/misc_utilities/classifychars.cpp
+++ b/src/misc_utilities/classifychars.cpp
@@ -146,7 +146,7 @@ int main( int argc, const char** argv )
         imshow ("Original", frame);
 
 	PipelineData pipeline_data(frame, Rect(0, 0, frame.cols, frame.rows), &config);
-	cvtColor(frame, frame, CV_BGR2GRAY);
+	cvtColor(frame, frame, COLOR_BGR2GRAY);
 	pipeline_data.crop_gray = Mat(frame, Rect(0, 0, frame.cols, frame.rows));
     pipeline_data.thresholds = produceThresholds(pipeline_data.crop_gray, &config);
     
@@ -311,7 +311,7 @@ void showDashboard(vector<Mat> images, vector<bool> selectedImages, int selected
   {
     Mat imgCopy(images[i].size(), images[i].type());
     images[i].copyTo(imgCopy);
-    cvtColor(imgCopy, imgCopy, CV_GRAY2BGR);
+    cvtColor(imgCopy, imgCopy, COLOR_GRAY2BGR);
     if (i == selectedIndex)
     {
       rectangle(imgCopy, Point(1,1), Point(imgCopy.size().width - 1, imgCopy.size().height -1), Scalar(0, 255, 0), 1);
@@ -344,7 +344,7 @@ vector<string> showCharSelection(Mat image, vector<Rect> charRegions, string sta
   {
     Mat imgCopy(image.size(), image.type());
     image.copyTo(imgCopy);
-    cvtColor(imgCopy, imgCopy, CV_GRAY2BGR);
+    cvtColor(imgCopy, imgCopy, COLOR_GRAY2BGR);
 
     rectangle(imgCopy, charRegions[curCharIdx], Scalar(0, 255, 0), 1);
 

--- a/src/misc_utilities/prepcharsfortraining.cpp
+++ b/src/misc_utilities/prepcharsfortraining.cpp
@@ -156,13 +156,13 @@ int main( int argc, const char** argv )
       bitwise_not(charImgCopy, charImgCopy);
 
       characterImg.copyTo(charImgCopy(Rect(X_OFFSET, Y_OFFSET, characterImg.cols, characterImg.rows)));
-      cvtColor(charImgCopy, charImgCopy, CV_BGR2GRAY);
+      cvtColor(charImgCopy, charImgCopy, COLOR_BGR2GRAY);
       bitwise_not(charImgCopy, charImgCopy);
 
       vector<vector<Point> > contours;
 
       //imshow("copy", charImgCopy);
-      findContours(charImgCopy, contours, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_SIMPLE);
+      findContours(charImgCopy, contours, RETR_EXTERNAL, CHAIN_APPROX_SIMPLE);
 
       float minHeightPercent = 0.35;
       int minHeight = (int) (((float) characterImg.rows) * minHeightPercent);
@@ -198,7 +198,7 @@ int main( int argc, const char** argv )
 
       //cout << "Cropped: " << cropRect.x << ":" << cropRect.y << " -- " << cropRect.width << ":" << cropRect.height << endl;
       Mat cropped(characterImg, cropRect);
-      cvtColor(cropped, cropped, CV_BGR2GRAY);
+      cvtColor(cropped, cropped, COLOR_BGR2GRAY);
 
       Rect destinationRect(xPos, yPos, tallestRect.width, tallestRect.height);
       //cout << "1" << endl;

--- a/src/misc_utilities/tagplates.cpp
+++ b/src/misc_utilities/tagplates.cpp
@@ -223,7 +223,7 @@ int main( int argc, const char** argv )
       frame.copyTo(tmpFrame);
       rectangle(tmpFrame, Point(xPos1, yPos1), Point(xPos2, yPos2), Scalar(0, 0, 255), 2);
       
-      rectangle(tmpFrame, Point(xPos1, yPos1 - 35), Point(xPos1 + 175, yPos1 - 5), Scalar(255, 255, 255), CV_FILLED);
+      rectangle(tmpFrame, Point(xPos1, yPos1 - 35), Point(xPos1 + 175, yPos1 - 5), Scalar(255, 255, 255), FILLED);
       putText(tmpFrame, curplatetag, Point(xPos1 + 2, yPos1 - 10), FONT_HERSHEY_PLAIN, 1.5, Scalar(100,50,0), 2);
       
       imshow("Input image", tmpFrame);

--- a/src/openalpr/alpr_impl.cpp
+++ b/src/openalpr/alpr_impl.cpp
@@ -115,7 +115,7 @@ namespace alpr
     // Convert image to grayscale if required
     Mat grayImg = img;
     if (img.channels() > 2)
-      cvtColor( img, grayImg, CV_BGR2GRAY );
+      cvtColor( img, grayImg, COLOR_BGR2GRAY );
     
     // Prewarp the image and ROIs if configured]
     std::vector<cv::Rect> warpedRegionsOfInterest = regionsOfInterest;

--- a/src/openalpr/colorfilter.cpp
+++ b/src/openalpr/colorfilter.cpp
@@ -41,7 +41,7 @@ namespace alpr
       cout << "ColorFilter: isGrayscale = " << grayscale << endl;
 
     this->hsv = Mat(image.size(), image.type());
-    cvtColor( image, this->hsv, CV_BGR2HSV );
+    cvtColor( image, this->hsv, COLOR_BGR2HSV );
     preprocessImage();
 
     this->charMask = characterMask;
@@ -118,7 +118,7 @@ namespace alpr
 
     vector<vector<Point> > contours;
     vector<Vec4i> hierarchy;
-    findContours(erodedCharMask, contours, hierarchy, CV_RETR_TREE, CV_CHAIN_APPROX_SIMPLE);
+    findContours(erodedCharMask, contours, hierarchy, RETR_TREE, CHAIN_APPROX_SIMPLE);
 
     vector<float> hMeans, sMeans, vMeans;
     vector<float> hStdDevs, sStdDevs, vStdDevs;
@@ -133,7 +133,7 @@ namespace alpr
       drawContours(singleCharMask, contours,
                    i, // draw this contour
                    cv::Scalar(255,255,255), // in
-                   CV_FILLED,
+                   FILLED,
                    8,
                    hierarchy
                   );
@@ -355,7 +355,7 @@ namespace alpr
       //displayImage(config, "COLOR filter Mask", colorMask);
       debugImagesSet.push_back(addLabel(imgDebug, "Color filter Debug"));
 
-      cvtColor(imgDebugHueOnly, imgDebugHueOnly, CV_HSV2BGR);
+      cvtColor(imgDebugHueOnly, imgDebugHueOnly, COLOR_HSV2BGR);
       debugImagesSet.push_back(addLabel(imgDebugHueOnly, "Color Filter Hue"));
 
       equalizeHist(imgDistanceFromCenter, imgDistanceFromCenter);

--- a/src/openalpr/detection/detector.cpp
+++ b/src/openalpr/detection/detector.cpp
@@ -69,7 +69,7 @@ namespace alpr
     
     if (frame.channels() > 2)
     {
-      cvtColor( frame, frame_gray, CV_BGR2GRAY );
+      cvtColor( frame, frame_gray, cv::COLOR_BGR2GRAY );
     }
     else
     {
@@ -85,7 +85,7 @@ namespace alpr
     if (detector_mask.mask_loaded && config->debugDetector)
     {
       frame_gray.copyTo(mask_debug_img);
-      cvtColor(frame_gray, mask_debug_img, CV_GRAY2BGR);
+      cvtColor(frame_gray, mask_debug_img, COLOR_GRAY2BGR);
     }
     
     vector<PlateRegion> detectedRegions;   

--- a/src/openalpr/detection/detectorcpu.cpp
+++ b/src/openalpr/detection/detectorcpu.cpp
@@ -62,7 +62,7 @@ namespace alpr
     equalizeHist( frame, frame );
     
     plate_cascade.detectMultiScale( frame, plates, config->detection_iteration_increase, config->detectionStrictness,
-                                      CV_HAAR_DO_CANNY_PRUNING,
+                                      0,
                                       //0|CV_HAAR_SCALE_IMAGE,
                                       min_plate_size, max_plate_size );
 

--- a/src/openalpr/detection/detectormask.cpp
+++ b/src/openalpr/detection/detectormask.cpp
@@ -48,7 +48,7 @@ namespace alpr
       
     this->mask = orig_mask;
     if (orig_mask.channels() > 2)
-      cvtColor( orig_mask, this->mask, CV_BGR2GRAY );
+      cvtColor( orig_mask, this->mask, COLOR_BGR2GRAY );
     else
       this->mask = orig_mask;
     

--- a/src/openalpr/detection/detectormorph.cpp
+++ b/src/openalpr/detection/detectormorph.cpp
@@ -58,7 +58,7 @@ namespace alpr {
     
     Mat img_open, img_result;
     Mat element = getStructuringElement(MORPH_RECT, Size(30, 4));
-    morphologyEx(frame_gray, img_open, CV_MOP_OPEN, element, cv::Point(-1, -1));
+    morphologyEx(frame_gray, img_open, MORPH_OPEN , element, cv::Point(-1, -1));
 
     img_result = frame_gray - img_open;
 
@@ -68,7 +68,7 @@ namespace alpr {
 
     //threshold image using otsu thresholding
     Mat img_threshold, img_open2;
-    threshold(img_result, img_threshold, 0, 255, CV_THRESH_OTSU + CV_THRESH_BINARY);
+    threshold(img_result, img_threshold, 0, 255, THRESH_OTSU + THRESH_BINARY);
 
     if (config->debugDetector && config->debugShowImages) {
       imshow("Threshold Detector", img_threshold);
@@ -89,9 +89,9 @@ namespace alpr {
       diamond.at<uchar>(0, 3) = 0;
       diamond.at<uchar>(1, 4) = 0;
 
-    morphologyEx(img_threshold, img_open2, CV_MOP_OPEN, diamond, cv::Point(-1, -1));
+    morphologyEx(img_threshold, img_open2, MORPH_OPEN , diamond, cv::Point(-1, -1));
     Mat rectElement = getStructuringElement(cv::MORPH_RECT, Size(13, 4));
-    morphologyEx(img_open2, img_threshold, CV_MOP_CLOSE, rectElement, cv::Point(-1, -1));
+    morphologyEx(img_open2, img_threshold, MORPH_CLOSE, rectElement, cv::Point(-1, -1));
 
     if (config->debugDetector && config->debugShowImages) {
       imshow("Close", img_threshold);
@@ -102,8 +102,8 @@ namespace alpr {
     vector< vector< Point> > contours;
     findContours(img_threshold,
             contours, // a vector of contours
-            CV_RETR_EXTERNAL, // retrieve the external contours
-            CV_CHAIN_APPROX_NONE); // all pixels of each contours
+            RETR_EXTERNAL, // retrieve the external contours
+            CHAIN_APPROX_NONE); // all pixels of each contours
 
     //Start to iterate to each contour founded
     vector<vector<Point> >::iterator itc = contours.begin();
@@ -159,13 +159,13 @@ namespace alpr {
 
               findContours(img_crop_th,
                       plateBlobs, // a vector of contours
-                      CV_RETR_LIST, // retrieve the contour list
-                      CV_CHAIN_APPROX_NONE); // all pixels of each contours
+                      RETR_LIST, // retrieve the contour list
+                      CHAIN_APPROX_NONE); // all pixels of each contours
 
               findContours(img_crop_th_inv,
                       plateBlobsInv, // a vector of contours
-                      CV_RETR_LIST, // retrieve the contour list
-                      CV_CHAIN_APPROX_NONE); // all pixels of each contours
+                      RETR_LIST, // retrieve the contour list
+                      CHAIN_APPROX_NONE); // all pixels of each contours
 
               int numBlobs = plateBlobs.size();
               int numBlobsInv = plateBlobsInv.size();

--- a/src/openalpr/detection/detectorocl.cpp
+++ b/src/openalpr/detection/detectorocl.cpp
@@ -118,7 +118,7 @@ namespace alpr
       equalizeHist( openclFrame, openclFrame );
 
       plate_cascade.detectMultiScale( openclFrame, plates, config->detection_iteration_increase, config->detectionStrictness,
-                                      CV_HAAR_DO_CANNY_PRUNING,
+                                      0,
                                       min_plate_size, max_plate_size );
 
       ocl_detector_mutex_m.unlock();
@@ -128,7 +128,7 @@ namespace alpr
       equalizeHist( orig_frame, orig_frame );
 
       plate_cascade.detectMultiScale( orig_frame, plates, config->detection_iteration_increase, config->detectionStrictness,
-                                      CV_HAAR_DO_CANNY_PRUNING,
+                                      0,
                                       min_plate_size, max_plate_size );
     }
 

--- a/src/openalpr/edges/edgefinder.cpp
+++ b/src/openalpr/edges/edgefinder.cpp
@@ -211,7 +211,7 @@ namespace alpr
     threshold(newCrop, thresholded_crop, 80, 255, cv::THRESH_OTSU);
 
     vector<vector<Point> > contours;
-    findContours(thresholded_crop, contours, RETR_EXTERNAL, CV_CHAIN_APPROX_SIMPLE );
+    findContours(thresholded_crop, contours, RETR_EXTERNAL, CHAIN_APPROX_SIMPLE );
 
     float MIN_AREA = 0.05 * newCrop.cols * newCrop.rows;
     for (unsigned int i = 0; i < contours.size(); i++)

--- a/src/openalpr/edges/platecorners.cpp
+++ b/src/openalpr/edges/platecorners.cpp
@@ -86,7 +86,7 @@ namespace alpr
 
       Mat imgCorners = Mat(inputImage.size(), inputImage.type());
       inputImage.copyTo(imgCorners);
-      cvtColor(imgCorners, imgCorners, CV_GRAY2BGR);
+      cvtColor(imgCorners, imgCorners, COLOR_GRAY2BGR);
 
       for (unsigned int linenum = 0; linenum < textLines.size(); linenum++)
       {
@@ -94,10 +94,10 @@ namespace alpr
           circle(imgCorners, textLines[linenum].textArea[i], 2, Scalar(0, 0, 0));
       }
 
-      line(imgCorners, this->bestTop.p1, this->bestTop.p2, Scalar(255, 0, 0), 1, CV_AA);
-      line(imgCorners, this->bestRight.p1, this->bestRight.p2, Scalar(0, 0, 255), 1, CV_AA);
-      line(imgCorners, this->bestBottom.p1, this->bestBottom.p2, Scalar(0, 0, 255), 1, CV_AA);
-      line(imgCorners, this->bestLeft.p1, this->bestLeft.p2, Scalar(255, 0, 0), 1, CV_AA);
+      line(imgCorners, this->bestTop.p1, this->bestTop.p2, Scalar(255, 0, 0), 1, LINE_AA);
+      line(imgCorners, this->bestRight.p1, this->bestRight.p2, Scalar(0, 0, 255), 1, LINE_AA);
+      line(imgCorners, this->bestBottom.p1, this->bestBottom.p2, Scalar(0, 0, 255), 1, LINE_AA);
+      line(imgCorners, this->bestLeft.p1, this->bestLeft.p2, Scalar(255, 0, 0), 1, LINE_AA);
 
       displayImage(pipelineData->config, "Winning top/bottom Boundaries", imgCorners);
     }
@@ -337,7 +337,7 @@ namespace alpr
       scoreKeeper.printDebugScores();
       Mat debugImg(this->inputImage.size(), this->inputImage.type());
       this->inputImage.copyTo(debugImg);
-      cvtColor(debugImg, debugImg, CV_GRAY2BGR);
+      cvtColor(debugImg, debugImg, COLOR_GRAY2BGR);
       line(debugImg, top.p1, top.p2, Scalar(0,0,255), 2);
       line(debugImg, bottom.p1, bottom.p2, Scalar(0,0,255), 2);
       //drawAndWait(&debugImg);

--- a/src/openalpr/edges/platelines.cpp
+++ b/src/openalpr/edges/platelines.cpp
@@ -99,17 +99,17 @@ namespace alpr
       Mat debugImgVert(edges.size(), edges.type());
       edges.copyTo(debugImgHoriz);
       edges.copyTo(debugImgVert);
-      cvtColor(debugImgHoriz,debugImgHoriz,CV_GRAY2BGR);
-      cvtColor(debugImgVert,debugImgVert,CV_GRAY2BGR);
+      cvtColor(debugImgHoriz,debugImgHoriz,COLOR_GRAY2BGR);
+      cvtColor(debugImgVert,debugImgVert,COLOR_GRAY2BGR);
 
       for( size_t i = 0; i < this->horizontalLines.size(); i++ )
       {
-        line( debugImgHoriz, this->horizontalLines[i].line.p1, this->horizontalLines[i].line.p2, Scalar(0,0,255), 1, CV_AA);
+        line( debugImgHoriz, this->horizontalLines[i].line.p1, this->horizontalLines[i].line.p2, Scalar(0,0,255), 1, LINE_AA);
       }
 
       for( size_t i = 0; i < this->verticalLines.size(); i++ )
       {
-        line( debugImgVert, this->verticalLines[i].line.p1, this->verticalLines[i].line.p2, Scalar(0,0,255), 1, CV_AA);
+        line( debugImgVert, this->verticalLines[i].line.p1, this->verticalLines[i].line.p2, Scalar(0,0,255), 1, LINE_AA);
       }
 
       vector<Mat> images;
@@ -220,7 +220,7 @@ namespace alpr
   Mat PlateLines::customGrayscaleConversion(Mat src)
   {
     Mat img_hsv;
-    cvtColor(src,img_hsv,CV_BGR2HSV);
+    cvtColor(src,img_hsv,COLOR_BGR2HSV);
 
     Mat grayscale = Mat(img_hsv.size(), CV_8U );
     Mat hue(img_hsv.size(), CV_8U );

--- a/src/openalpr/licenseplatecandidate.cpp
+++ b/src/openalpr/licenseplatecandidate.cpp
@@ -90,7 +90,7 @@ namespace alpr
     if (pipeline_data->color_deskewed.channels() > 2)
     {
       // Make a grayscale copy as well for faster processing downstream
-      cv::cvtColor(pipeline_data->color_deskewed, pipeline_data->crop_gray, CV_BGR2GRAY);
+      cv::cvtColor(pipeline_data->color_deskewed, pipeline_data->crop_gray, COLOR_BGR2GRAY);
     }
     else
     {

--- a/src/openalpr/motiondetector.cpp
+++ b/src/openalpr/motiondetector.cpp
@@ -51,7 +51,7 @@ cv::Rect MotionDetector::MotionDetect(cv::Mat* frame)
 	//Remove noise
 	cv::erode(fgMaskMOG2, fgMaskMOG2, getStructuringElement(cv::MORPH_RECT, cv::Size(6, 6)));
 	// Find the contours of motion areas in the image
-	findContours(fgMaskMOG2, contours, hierarchy, CV_RETR_LIST, CV_CHAIN_APPROX_SIMPLE);
+	findContours(fgMaskMOG2, contours, hierarchy, RETR_LIST, CHAIN_APPROX_SIMPLE);
 	// Find the bounding rectangles of the areas of motion
 	if (contours.size() > 0)
 	{

--- a/src/openalpr/ocr/segmentation/charactersegmenter.cpp
+++ b/src/openalpr/ocr/segmentation/charactersegmenter.cpp
@@ -151,7 +151,7 @@ namespace alpr
           Mat boxMask = getCharBoxMask(pipeline_data->thresholds[i], candidateBoxes);
           pipeline_data->thresholds[i].copyTo(cleanImg);
           bitwise_and(cleanImg, boxMask, cleanImg);
-          cvtColor(cleanImg, cleanImg, CV_GRAY2BGR);
+          cvtColor(cleanImg, cleanImg, COLOR_GRAY2BGR);
 
           for (unsigned int c = 0; c < candidateBoxes.size(); c++)
             rectangle(cleanImg, candidateBoxes[c], Scalar(0, 255, 0), 1);
@@ -376,12 +376,12 @@ namespace alpr
 
     if (this->config->debugCharSegmenter)
     {
-      cvtColor(histoImg, histoImg, CV_GRAY2BGR);
+      cvtColor(histoImg, histoImg, COLOR_GRAY2BGR);
       line(histoImg, Point(0, histoImg.rows - 1 - bestRowIndex), Point(histoImg.cols, histoImg.rows - 1 - bestRowIndex), Scalar(0, 255, 0));
 
       Mat imgBestBoxes(img.size(), img.type());
       img.copyTo(imgBestBoxes);
-      cvtColor(imgBestBoxes, imgBestBoxes, CV_GRAY2BGR);
+      cvtColor(imgBestBoxes, imgBestBoxes, COLOR_GRAY2BGR);
       for (unsigned int i = 0; i < bestBoxes.size(); i++)
         rectangle(imgBestBoxes, bestBoxes[i], Scalar(0, 255, 0));
 
@@ -408,7 +408,7 @@ namespace alpr
       Mat thresholdsCopy = Mat::zeros(thresholds[i].size(), thresholds[i].type());
 
       thresholds[i].copyTo(thresholdsCopy, textLineMask);
-      findContours(thresholdsCopy, contours, hierarchy, CV_RETR_TREE, CV_CHAIN_APPROX_SIMPLE);
+      findContours(thresholdsCopy, contours, hierarchy, RETR_TREE, CHAIN_APPROX_SIMPLE);
 
       for (unsigned int c = 0; c < contours.size(); c++)
       {
@@ -549,7 +549,7 @@ namespace alpr
       //morphologyEx(thresholds[i], tempImg, MORPH_CLOSE, element);
       //drawAndWait(&tempImg);
 
-      findContours(tempImg, contours, RETR_EXTERNAL, CV_CHAIN_APPROX_SIMPLE);
+      findContours(tempImg, contours, RETR_EXTERNAL, CHAIN_APPROX_SIMPLE);
 
       for (unsigned int j = 0; j < charRegions.size(); j++)
       {
@@ -570,11 +570,11 @@ namespace alpr
           if (r.height <= MIN_SPECKLE_HEIGHT || r.width <= MIN_SPECKLE_WIDTH_PX)
           {
             // Erase this speckle
-            drawContours(thresholds[i], contours, c, Scalar(0,0,0), CV_FILLED);
+            drawContours(thresholds[i], contours, c, Scalar(0,0,0), FILLED);
 
             if (this->config->debugCharSegmenter)
             {
-              drawContours(imgDbgCleanStages[i], contours, c, COLOR_DEBUG_SPECKLES, CV_FILLED);
+              drawContours(imgDbgCleanStages[i], contours, c, COLOR_DEBUG_SPECKLES, FILLED);
             }
           }
           else
@@ -650,7 +650,7 @@ namespace alpr
       for (unsigned int j = 0; j < charRegions.size(); j++)
       {
         Mat boxChar = Mat::zeros(thresholds[i].size(), CV_8U);
-        rectangle(boxChar, charRegions[j], Scalar(255,255,255), CV_FILLED);
+        rectangle(boxChar, charRegions[j], Scalar(255,255,255), FILLED);
 
         bitwise_and(thresholds[i], boxChar, boxChar);
 
@@ -663,13 +663,13 @@ namespace alpr
 
         if (meanAfter < meanBefore * (1-MIN_PERCENT_CHUNK_REMOVED))
         {
-          rectangle(thresholds[i], charRegions[j], Scalar(0,0,0), CV_FILLED);
+          rectangle(thresholds[i], charRegions[j], Scalar(0,0,0), FILLED);
 
           if (this->config->debugCharSegmenter)
           {
             //vector<Mat> tmpDebug;
             //Mat thresholdCopy2 = Mat::zeros(thresholds[i].size(), CV_8U);
-            //rectangle(thresholdCopy2, charRegions[j], Scalar(255,255,255), CV_FILLED);
+            //rectangle(thresholdCopy2, charRegions[j], Scalar(255,255,255), FILLED);
             //tmpDebug.push_back(addLabel(thresholdCopy2, "box Mask"));
             //bitwise_and(thresholds[i], thresholdCopy2, thresholdCopy2);
             //tmpDebug.push_back(addLabel(thresholdCopy2, "box Mask + Thresh"));
@@ -684,7 +684,7 @@ namespace alpr
             cout << "Segmentation Filter Clean by Color: before=" << meanBefore << " after=" << meanAfter  << endl;
 
             Point topLeft(charRegions[j].x, charRegions[j].y);
-            circle(imgDbgCleanStages[i], topLeft, 5, COLOR_DEBUG_COLORFILTER, CV_FILLED);
+            circle(imgDbgCleanStages[i], topLeft, 5, COLOR_DEBUG_COLORFILTER, FILLED);
           }
         }
       }
@@ -713,11 +713,11 @@ namespace alpr
         //float minArea = charRegions[j].area() * MIN_AREA_PERCENT;
 
         Mat tempImg = Mat::zeros(thresholds[i].size(), thresholds[i].type());
-        rectangle(tempImg, charRegions[j], Scalar(255,255,255), CV_FILLED);
+        rectangle(tempImg, charRegions[j], Scalar(255,255,255), FILLED);
         bitwise_and(thresholds[i], tempImg, tempImg);
 
         vector<vector<Point> > contours;
-        findContours(tempImg, contours, RETR_EXTERNAL, CV_CHAIN_APPROX_SIMPLE);
+        findContours(tempImg, contours, RETR_EXTERNAL, CHAIN_APPROX_SIMPLE);
 
         vector<Point> allPointsInBox;
         for (unsigned int c = 0; c < contours.size(); c++)
@@ -1026,7 +1026,7 @@ namespace alpr
       bitwise_and(tempImg, boxMask, tempImg);
 
       vector<vector<Point> > subContours;
-      findContours(tempImg, subContours, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_SIMPLE);
+      findContours(tempImg, subContours, RETR_EXTERNAL, CHAIN_APPROX_SIMPLE);
       int tallestContourIdx = -1;
       int tallestContourHeight = 0;
       int tallestContourWidth = 0;

--- a/src/openalpr/pipeline_data.cpp
+++ b/src/openalpr/pipeline_data.cpp
@@ -12,7 +12,7 @@ namespace alpr
 
     if (colorImage.channels() > 2)
     {
-      cvtColor(colorImage, grayImage, CV_BGR2GRAY);
+      cvtColor(colorImage, grayImage, COLOR_BGR2GRAY);
     }
     else
     {

--- a/src/openalpr/textdetection/characteranalysis.cpp
+++ b/src/openalpr/textdetection/characteranalysis.cpp
@@ -253,14 +253,14 @@ namespace alpr
       {
         Mat tmp(pipeline_data->thresholds[z].size(), pipeline_data->thresholds[z].type());
         pipeline_data->thresholds[z].copyTo(tmp);
-        cvtColor(tmp, tmp, CV_GRAY2BGR);
+        cvtColor(tmp, tmp, COLOR_GRAY2BGR);
 
         tempDash.push_back(tmp);
       }
 
       Mat bestVal(this->bestThreshold.size(), this->bestThreshold.type());
       this->bestThreshold.copyTo(bestVal);
-      cvtColor(bestVal, bestVal, CV_GRAY2BGR);
+      cvtColor(bestVal, bestVal, COLOR_GRAY2BGR);
 
       for (unsigned int z = 0; z < this->bestContours.size(); z++)
       {
@@ -289,7 +289,7 @@ namespace alpr
       drawContours(charMask, bestContours.contours,
                    i, // draw this contour
                    cv::Scalar(255,255,255), // in
-                   CV_FILLED,
+                   FILLED,
                    8,
                    bestContours.hierarchy,
                    1
@@ -592,7 +592,7 @@ namespace alpr
 
       totalChars++;
       tempFullContour = Mat::zeros(plateMask.size(), CV_8U);
-      drawContours(tempFullContour, textContours.contours, i, Scalar(255,255,255), CV_FILLED, 8, textContours.hierarchy);
+      drawContours(tempFullContour, textContours.contours, i, Scalar(255,255,255), FILLED, 8, textContours.hierarchy);
       bitwise_and(tempFullContour, plateMask, tempMaskedContour);
       
       textContours.goodIndices[i] = false;

--- a/src/openalpr/textdetection/linefinder.cpp
+++ b/src/openalpr/textdetection/linefinder.cpp
@@ -44,7 +44,7 @@ namespace alpr
 
     vector<vector<Point> > linesFound;
 
-    cvtColor(image, image, CV_GRAY2BGR);
+    cvtColor(image, image, COLOR_GRAY2BGR);
 
     vector<CharPointInfo> charPoints;
 
@@ -258,7 +258,7 @@ namespace alpr
       
       Mat debugImg(pipeline_data->thresholds[1].size(), pipeline_data->thresholds[1].type());
       pipeline_data->thresholds[1].copyTo(debugImg);
-      cvtColor(debugImg, debugImg, CV_GRAY2BGR);
+      cvtColor(debugImg, debugImg, COLOR_GRAY2BGR);
       
       LineSegment orig_top_line(bestLine[0], bestLine[1]);
       LineSegment secondline_top = orig_top_line.getParallelLine(best_secondline_top_pixel_offset_from_bestline_top + 1);
@@ -403,7 +403,7 @@ namespace alpr
       // Draw the winning line segment
 
       Mat tempImg = Mat::zeros(Size(contours.width, contours.height), CV_8U);
-      cvtColor(tempImg, tempImg, CV_GRAY2BGR);
+      cvtColor(tempImg, tempImg, COLOR_GRAY2BGR);
 
       cv::line(tempImg, topLines[bestScoreIndex].p1, topLines[bestScoreIndex].p2, Scalar(0, 0, 255), 2);
       cv::line(tempImg, bottomLines[bestScoreIndex].p1, bottomLines[bestScoreIndex].p2, Scalar(0, 0, 255), 2);

--- a/src/openalpr/textdetection/platemask.cpp
+++ b/src/openalpr/textdetection/platemask.cpp
@@ -118,7 +118,7 @@ namespace alpr
       drawContours(mask, contours[winningIndex].contours,
                    winningParentId, // draw this contour
                    cv::Scalar(255,255,255), // in
-                   CV_FILLED,
+                   FILLED,
                    8,
                    contours[winningIndex].hierarchy,
                    0
@@ -141,7 +141,7 @@ namespace alpr
 
       vector<vector<Point> > contoursSecondRound;
 
-      findContours(mask, contoursSecondRound, CV_RETR_EXTERNAL, CV_CHAIN_APPROX_SIMPLE);
+      findContours(mask, contoursSecondRound, RETR_EXTERNAL, CHAIN_APPROX_SIMPLE);
       int biggestContourIndex = -1;
       double largestArea = 0;
       for (unsigned int c = 0; c < contoursSecondRound.size(); c++)
@@ -167,7 +167,7 @@ namespace alpr
         drawContours(mask, tempvec,
                      0, // draw this contour
                      cv::Scalar(255,255,255), // in
-                     CV_FILLED,
+                     FILLED,
                      8,
                      contours[winningIndex].hierarchy,
                      0

--- a/src/openalpr/textdetection/textcontours.cpp
+++ b/src/openalpr/textdetection/textcontours.cpp
@@ -47,8 +47,8 @@ namespace alpr
     findContours(tempThreshold,
                  contours, // a vector of contours
                  hierarchy,
-                 CV_RETR_TREE, // retrieve all contours
-                 CV_CHAIN_APPROX_SIMPLE ); // all pixels of each contours
+                 RETR_TREE, // retrieve all contours
+                 CHAIN_APPROX_SIMPLE ); // all pixels of each contours
 
     for (unsigned int i = 0; i < contours.size(); i++)
       goodIndices.push_back(true);
@@ -113,7 +113,7 @@ namespace alpr
       Mat img_contours(baseImage.size(), CV_8U);
       baseImage.copyTo(img_contours);
 
-      cvtColor(img_contours, img_contours, CV_GRAY2RGB);
+      cvtColor(img_contours, img_contours, COLOR_GRAY2RGB);
 
       vector<vector<Point> > allowedContours;
       for (unsigned int i = 0; i < this->contours.size(); i++)

--- a/src/openalpr/textdetection/textline.cpp
+++ b/src/openalpr/textdetection/textline.cpp
@@ -115,7 +115,7 @@ namespace alpr
 
     baseImage.copyTo(debugImage);
 
-    cv::cvtColor(debugImage, debugImage, CV_GRAY2BGR);
+    cv::cvtColor(debugImage, debugImage, COLOR_GRAY2BGR);
 
 
     fillConvexPoly(debugImage, linePolygon.data(), linePolygon.size(), Scalar(0,0,165));

--- a/src/openalpr/utility.cpp
+++ b/src/openalpr/utility.cpp
@@ -84,10 +84,10 @@ namespace alpr
 
     cout << " Adding label " << label << endl;
     if (input.type() == CV_8U)
-      cvtColor(newImage, newImage, CV_GRAY2BGR);
+      cvtColor(newImage, newImage, COLOR_GRAY2BGR);
 
-    rectangle(newImage, Point(0,0), Point(input.cols, extraHeight), bg, CV_FILLED);
-    putText(newImage, label, Point(5, extraHeight - 5), CV_FONT_HERSHEY_PLAIN  , 0.7, fg);
+    rectangle(newImage, Point(0,0), Point(input.cols, extraHeight), bg, FILLED);
+    putText(newImage, label, Point(5, extraHeight - 5), FONT_HERSHEY_PLAIN  , 0.7, fg);
 
     rectangle(newImage, Point(0,0), Point(newImage.cols - 1, newImage.rows -1), border_color, border_size);
 
@@ -565,7 +565,7 @@ int levenshteinDistance (const std::string &s1, const std::string &s2, int max)
     drawContours(innerArea, contours,
                  contourIndex, // draw this contour
                  cv::Scalar(255,255,255), // in
-                 CV_FILLED,
+                 FILLED,
                  8,
                  hierarchy,
                  2

--- a/src/statedetection/featurematcher.cpp
+++ b/src/statedetection/featurematcher.cpp
@@ -256,7 +256,7 @@ namespace alpr
         Mat img = imread( fullpath );
 
         // convert to gray and resize to the size of the templates
-        cvtColor(img, img, CV_BGR2GRAY);
+        cvtColor(img, img, COLOR_BGR2GRAY);
 
         if( img.empty() )
         {


### PR DESCRIPTION
OpenCV 4 removes most or all of the `CV_` constants, so this pull request changes those to OpenCV 4 constants. With this OpenALPR can now compile on Arch Linux