### PR TITLE
Crash fix related to data returned by tesseract

### DIFF
--- a/runtime_data/config/eu.conf
+++ b/runtime_data/config/eu.conf
@@ -33,7 +33,7 @@ min_plate_size_width_px = 65
 min_plate_size_height_px = 18
 
 ; Results with fewer or more characters will be discarded
-postprocess_min_characters = 5
+postprocess_min_characters = 4
 postprocess_max_characters = 8
 
 ocr_language = leu

--- a/src/openalpr/ocr/tesseract_ocr.cpp
+++ b/src/openalpr/ocr/tesseract_ocr.cpp
@@ -86,6 +86,8 @@ namespace alpr
         tesseract::PageIteratorLevel level = tesseract::RIL_SYMBOL;
         do
         {
+          if (ri->Empty(level)) continue;
+
           const char* symbol = ri->GetUTF8Text(level);
           float conf = ri->Confidence(level);
 


### PR DESCRIPTION
Fixes a bug that could crash OpenAlpr if tesseract didn't return the expected data.