### PR TITLE
tesseract crash fix

### DIFF
--- a/src/openalpr/ocr/tesseract_ocr.cpp
+++ b/src/openalpr/ocr/tesseract_ocr.cpp
@@ -86,6 +86,8 @@ namespace alpr
         tesseract::PageIteratorLevel level = tesseract::RIL_SYMBOL;
         do
         {
+          if (ri->Empty(level)) continue;
+          
           const char* symbol = ri->GetUTF8Text(level);
           float conf = ri->Confidence(level);
 


### PR DESCRIPTION
Fixes a bug which would cause Alpr to crash if tesseract didn't return the expected data