### PR TITLE
Fixes minimum length of plate-chars for EU

### DIFF
--- a/runtime_data/config/eu.conf
+++ b/runtime_data/config/eu.conf
@@ -33,7 +33,7 @@ min_plate_size_width_px = 65
 min_plate_size_height_px = 18
 
 ; Results with fewer or more characters will be discarded
-postprocess_min_characters = 5
+postprocess_min_characters = 4
 postprocess_max_characters = 8
 
 ocr_language = leu


### PR DESCRIPTION
Changes the minimum character length of European plates from 5 to 4, since German plates can be 4 chars long.