### PR TITLE
class Alpr: Set self.loaded to False before exception

### DIFF
--- a/src/bindings/python/openalpr/openalpr.py
+++ b/src/bindings/python/openalpr/openalpr.py
@@ -42,6 +42,7 @@ class Alpr:
         :param runtime_dir: The path to the OpenALPR runtime data directory
         :return: An OpenALPR instance
         """
+        self.loaded = False  # Will be set to True at the end of this method.
         country = _convert_to_charp(country)
         config_file = _convert_to_charp(config_file)
         runtime_dir = _convert_to_charp(runtime_dir)


### PR DESCRIPTION
If an exception is raised (like line 62, etc.) then `self.loaded` is _never_ defined so subsequent code fails when trying to determine if `Alpr` has successfully loaded.  There are currently [46 open issues related to `loaded`](https://github.com/openalpr/openalpr/search?p=2&q=loaded&type=issues).  Many of these are [`AttributeError` issues](https://github.com/openalpr/openalpr/search?q=AttributeError&type=issues) caused because `self.loaded` is only defined at the end of this method on (line 117).

Closes #311
Closes #414
Closes #426
Closes #461 
Closes #508
Closes #533
Closes #660
Closes #732
Closes #738
Closes #764
Closes #806
Closes #837 
Closes #913 
Closes #916 
Related to #555
Related to Homebrew/homebrew-core#89948
https://groups.google.com/g/openalpr/search?q=AttributeError

@matthill Your review, please.